### PR TITLE
Use postgresql on arm64

### DIFF
--- a/untangle-database-config/debian/control
+++ b/untangle-database-config/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.8.0
 
 Package: untangle-database-config
 Architecture: any
-Depends: untangle-postgresql-config [!armel !armhf !arm64], sqlite3 [armel armhf arm64], python-sqlite [armel armhf arm64]
+Depends: untangle-postgresql-config [!armel !armhf], sqlite3 [armel armhf], python-sqlite [armel armhf]
 Description: Untangle Database config
  The Untangle database config
 

--- a/untangle-postgresql-config/debian/control
+++ b/untangle-postgresql-config/debian/control
@@ -7,7 +7,7 @@ Build-Depends: systemd, debhelper (>> 3.0.0)
 Standards-Version: 3.8.0
 
 Package: untangle-postgresql-config
-Architecture: i386 amd64
+Architecture: i386 amd64 arm64
 Depends: systemd, procps (>= 3.2.7-2~bpo.1), untangle-hardware-config, postgresql-client-9.6, postgresql-9.6
 Description: Untangle Postgres wrapper package
  The Untangle Postgres config for Postgres 8.3


### PR DESCRIPTION
The earlier patchsets I submitted for arm64 used the same set up (with installed packages) as armel/armhf, this meant using sqlite as the reports database.

As we aren't as resource constrained on arm64, change to using postgresql as the reports database.
If we have a smaller arm64 device in the future, I guess this can be configured per device with a hardware package?