### PR TITLE
Fix Apache ssl.conf to relax certificate requirements

### DIFF
--- a/untangle-apache2-config/debian/untangle-apache2-config.postinst
+++ b/untangle-apache2-config/debian/untangle-apache2-config.postinst
@@ -14,6 +14,10 @@ fi
 
 # disable SSLv2 and SSLv3 (bug #12028)
 sed -e 's/SSLProtocol all.*/SSLProtocol all -SSLv2 -SSLv3 -TLSv1/' -i /etc/apache2/mods-available/ssl.conf
+
+# Relax restrictions on certificate hash requirements (bug #NGFW-13096)
+sed -e 's/SSLCipherSuite .*/SSLCipherSuite ALL:@SECLEVEL=0/' -i /etc/apache2/mods-available/ssl.conf
+
 # remove directive not supported in apache 2.4
 perl -i -pe 's/^SSLMutex/#SSLMutex/' -i /etc/apache2/mods-available/ssl.conf
 


### PR DESCRIPTION
On Buster, Apache is configured with strict certificate security requirements. This prevents Apache from starting after upgrade on systems with older certificates that don't meet current best practices (e.g. sha1)

This fix modifies the mods-available/ssl.conf file in the postinst script to allow these older certs to work.
