### PR TITLE
Ensure depmod finishes before the uvm starts

### DIFF
--- a/untangle-hardware-config/debian/untangle-hardware-config.service
+++ b/untangle-hardware-config/debian/untangle-hardware-config.service
@@ -7,4 +7,4 @@ ExecStart=/bin/run-parts --lsbsysinit -v /etc/untangle/startup.d
 RemainAfterExit=true
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=multi-user.target untangle-vm.service


### PR DESCRIPTION
One of the things that untangle-hardware-config does is call
depmod -a.  On most boots this takes almost no time at all, but
on the boot after we've changed kernels, this depmod call might
take a while.  And the module loading that we do prior to starting
the uvm depends on depmod being finished.  So explicitly ensure that
the untangle-linux-config service finishes (ensuring that depmod
has finished) before starting the untangle-vm service.

NGFW-13231