### PR TITLE
Create possibly missing directory

### DIFF
--- a/untangle-freeradius-config/debian/untangle-freeradius-config.postinst
+++ b/untangle-freeradius-config/debian/untangle-freeradius-config.postinst
@@ -6,6 +6,15 @@
 # already uses symlinks from xxx-available to xxx-enabled to turn
 # stuff on and off so this isn't as awful as it first seems.
 
+# NGFW-13596 At least two systems were observed where this directory
+# was missing. It is supposed to be created by the freeradius-config
+# package but we double check here just to be sure.
+if [ ! -d /etc/freeradius/3.0/sites-enabled ]
+then
+    mkdir /etc/freeradius/3.0/sites-enabled
+    chown freerad:freerad /etc/freeradius/3.0/sites-enabled
+fi
+
 # create symlinks in /etc/freeradius/3.0/sites-enabled
 ln -s -f ../../untangle/default /etc/freeradius/3.0/sites-enabled/default
 ln -s -f ../../untangle/inner-tunnel /etc/freeradius/3.0/sites-enabled/inner-tunnel


### PR DESCRIPTION
At least two systems were observed where the sites-enabled directory was missing. It is supposed to be created by the freeradius-config package but we double check and create if missing in our untangle-freeradius-config postinst script just to be sure.
