### PR TITLE
NGFW-14464 Fixed alias command in untangle-linux-config

### DIFF
--- a/untangle-linux-config/debian/preinst
+++ b/untangle-linux-config/debian/preinst
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Enables aliases in bash script
+shopt -s expand_aliases
+
 # List block devices with filter expression to exclude floppy, ROM and part devices
 alias list_blk='lsblk --path --list --noheadings | grep -v "/dev/fd\| rom \| part " | awk "{print $1 ; exit}"'
 


### PR DESCRIPTION
Using `shopt -s expand_aliases` to enable alias in bash script
Reference: **[https://stackoverflow.com/a/24054245](https://stackoverflow.com/a/24054245)**

Test with a sample script,
```
root @ arista] ~ # cat alias-test.sh 
#!/bin/bash

shopt -s expand_aliases

# List block devices with filter expression to exclude floppy, ROM and part devices
alias list_blk='lsblk --path --list --noheadings | grep -v "/dev/fd\| rom \| part " | awk "{print $1 ; exit}"'

## functions
first_disk() {
  list_blk
}

set_debconf_grub_install_disk() {
  echo "set grub-pc/install_devices $1" 
}

set_debconf_grub_install_disk $(first_disk)
```

Result,
```
[root @ arista] ~ # ./alias-test.sh   
set grub-pc/install_devices /dev/sda
```