### PR TITLE
ngfw-13297: Updating High Memory rule to 4GB

### DIFF
--- a/untangle-suricata-config/files/usr/share/untangle-suricata-config/current/templates/defaults.js
+++ b/untangle-suricata-config/files/usr/share/untangle-suricata-config/current/templates/defaults.js
@@ -91,7 +91,7 @@
                     "javaClass":"com.untangle.app.intrusion_prevention.IntrusionPreventionRuleCondition",
                     "type":"SYSTEM_MEMORY",
                     "comparator":">=",
-                    "value":"2147483648"
+                    "value":"4294967296"
                 },{
                     "javaClass":"com.untangle.app.intrusion_prevention.IntrusionPreventionRuleCondition",
                     "type":"CLASSTYPE",


### PR DESCRIPTION
Acceptance criteria:
Update High Memory rule from 2GB to 4GB

Before applying PR changes High Memory rule in IPS is 2GB, refer screenshot
![Screenshot from 2024-02-13 15-47-45](https://github.com/untangle/ngfw_pkgs/assets/154513962/54dc45c2-7b84-4730-a2bc-f994c4dfeaaf)


Testing changes
1. Built untangle-suricata-config pkg locally for the artifact containing the changes, using following command
     `PACKAGE=untangle-suricata-config FORCE=1 UPLOAD=local docker-compose -f docker-compose.build.yml run build`
2. Artifact with *.deb copied to NGFW server, and installed package using `dpkg -i `command, refer screen shot

![Screenshot from 2024-02-13 16-42-28](https://github.com/untangle/ngfw_pkgs/assets/154513962/33464c71-ac3d-492e-890b-c76ccad3c0e6)

4. Restarted NGFW server , using following command
    ` /etc/init.d/untangle-vm restart`

5. After restart, IPS High Memory Rule modified to 4GB,, refer screen shot
![Screenshot from 2024-02-13 16-03-31](https://github.com/untangle/ngfw_pkgs/assets/154513962/d8ccc985-f22d-4ac9-bc19-24d8045e5c3d)


