### PR TITLE
ngfw-13910 add help base url in uris_override

### DIFF
--- a/untangle-region-eu/files/usr/share/untangle/conf/uris_override.js
+++ b/untangle-region-eu/files/usr/share/untangle/conf/uris_override.js
@@ -97,6 +97,10 @@
                 "javaClass": "com.untangle.uvm.UriTranslation",
                 "uri": "https://launchpad.edge.arista.com/",
                 "host": "eu.edge.arista.com"
+            },
+            {
+                "javaClass": "com.untangle.uvm.UriTranslation",
+                "uri": "https://wiki.edge.arista.com/get.php",
             }
         ]
     },


### PR DESCRIPTION
Updated untangle-region-eu
Added help base url in uris_override.js file

For Local Testing

Built the package using command `PACKAGE=untangle-region-eu FORCE=1 VERBOSE=1 UPLOAD=local docker compose -f docker-compose.build.yml run build`

Installed the package in local NGFW using command `dpkg -i <filename>.deb`

[Related PR for ngfw_src](https://github.com/untangle/ngfw_src/pull/567)