### PR TITLE
NGFW-13296 Creating /bin symlink if missing/broken

### DIFF
--- a/untangle-linux-config/debian/postinst
+++ b/untangle-linux-config/debian/postinst
@@ -5,7 +5,9 @@ set -x
 bin_sym_link=/bin
 # NGFW-13296 create /bin symlink if missing/broken
 if [ ! -L ${bin_sym_link} ] || [ ! -e ${bin_sym_link} ] ; then
-  ln -s /usr/bin ${bin_sym_link}
+  cd /
+  ln -s usr/bin ${bin_sym_link}
+  cd -
 fi
 
 # we don't deal with grub on arm* at all

--- a/untangle-linux-config/debian/postinst
+++ b/untangle-linux-config/debian/postinst
@@ -2,6 +2,12 @@
 
 set -x
 
+bin_sym_link=/bin
+# NGFW-13296 create /bin symlink if missing/broken
+if [ ! -L ${bin_sym_link} ] || [ ! -e ${bin_sym_link} ] ; then
+  ln -s /usr/bin ${bin_sym_link}
+fi
+
 # we don't deal with grub on arm* at all
 uname -m | grep -qE '^arm' && exit 0
 


### PR DESCRIPTION
- Creating /bin symbolic link to usr/bin if missing/broken
- Turns out without having /bin symlink on bullseye is like a broken system. I wasn't able to install any package without this sym link. 
Hence I validated the symlink creation instruction manually and also checked the package logs to verify if there are no errors.