### PR TITLE
ngfw-14614: quagga-removal , adding frr dependancy

### DIFF
--- a/untangle-sync-settings/debian/control
+++ b/untangle-sync-settings/debian/control
@@ -8,9 +8,9 @@ Standards-Version: 3.9.8
 
 Package: untangle-sync-settings
 Architecture: all
-Conflicts: untangle-netd
-Replaces: untangle-netd
-Provides: untangle-netd
+Conflicts: untangle-netd, quagga
+Replaces: untangle-netd, quagga
+Provides: untangle-netd, quagga
 Depends: ${misc:Depends}, bridge-utils,
          crda,
          dash,


### PR DESCRIPTION
After adding FRR dependancy , getting following error
`apt-get dist-upgrade  -o DPkg::Options::=--force-confnew -o DPkg::Options::=--force-confmiss --yes --force-yes --fix-broken --purge -o Debug::Pkgproblemresolver=1 -o Debug::Pkgpolicy=1 
Reading package lists...
Prio of /var/lib/dpkg/status 100
Prio of /var/lib/apt/lists/package-server.untangle.int_public_bullseye_dists_current_main_binary-amd64_Packages 500
Prio of /var/lib/dpkg/status 100
Prio of /var/lib/apt/lists/package-server.untangle.int_public_bullseye_dists_current_main_binary-amd64_Packages 500
Prio of /var/lib/dpkg/status 100
Prio of /var/lib/apt/lists/package-server.untangle.int_public_bullseye_dists_current_main_binary-amd64_Packages 999
Building dependency tree...
Reading state information...
Calculating upgrade...Starting pkgProblemResolver with broken count: 1
Starting 2 pkgProblemResolver with broken count: 1
Investigating (0) frr:amd64 < none -> 7.5.1-1.1+deb11u2 @un uN Ib >
Broken frr:amd64 Conflicts on quagga:amd64 < 1.2.4-3bullseye @ii mK >
Considering quagga:amd64 -1 as a solution to frr:amd64 3
Added quagga:amd64 to the remove list
Broken frr:amd64 Conflicts on quagga-bgpd:amd64 < 1.2.4-3bullseye @ii mK >
Considering quagga-bgpd:amd64 0 as a solution to frr:amd64 3
Added quagga-bgpd:amd64 to the remove list
Broken frr:amd64 Conflicts on quagga-core:amd64 < 1.2.4-3bullseye @ii mK >
Considering quagga-core:amd64 7 as a solution to frr:amd64 3
Holding Back frr:amd64 rather than change quagga-core:amd64
Investigating (1) untangle-sync-settings:amd64 < 17.1.0.20240108T122618.4d0b8b090-1bullseye -> 17.2.0.20240522T090425.017934487-1bullseye @ii umU Ib >
Broken untangle-sync-settings:amd64 Depends on frr:amd64 < none | 7.5.1-1.1+deb11u2 @un uH >
Considering frr:amd64 3 as a solution to untangle-sync-settings:amd64 46
Holding Back untangle-sync-settings:amd64 rather than change frr:amd64
Try to Re-Instate (2) untangle-sync-settings:amd64
Done

The following packages were automatically installed and are no longer required:
libwpe-1.0-1 libwpebackend-fdo-1.0-1
Use 'apt autoremove' to remove them.
The following NEW packages will be installed:
linux-headers-5.10.0-27-common-untangle
linux-headers-5.10.0-27-untangle-amd64 linux-image-5.10.0-27-amd64
linux-image-5.10.0-27-untangle-amd64 python3-pem
The following packages have been kept back:
untangle-sync-settings`

Using this to fix the issue,
https://wiki.debian.org/RenamingPackages?action=show&redirect=Renaming_a_Package


