### PR TITLE
NGFW-14626 Disabled apache status mod in `untangle-apache2-config` package

### DIFF
--- a/untangle-apache2-config/debian/untangle-apache2-config.postinst
+++ b/untangle-apache2-config/debian/untangle-apache2-config.postinst
@@ -94,6 +94,9 @@ a2dismod $A2DISMOD_OPTS userdir
 /usr/sbin/a2dismod $A2DISMOD_OPTS mpm_prefork
 /usr/sbin/a2enmod mpm_worker
 
+# Disable status module
+/usr/sbin/a2dismod $A2DISMOD_OPTS status
+
 # enable UVM site
 a2dissite default >/dev/null 2>&1 # wheezy
 a2dissite 000-default >/dev/null 2>&1 # jessie


### PR DESCRIPTION
Disabled the status mod which shows apache server status `firewall_IP:port/server-status`
![Screenshot from 2024-06-05 20-09-48](https://github.com/untangle/ngfw_pkgs/assets/154527616/e892631f-9533-4d39-a12a-b77287c5cc83)


