### PR TITLE
ngfw-14672 updating untangle.conf file for syslog configuration of uv…

### DIFF
--- a/untangle-system-config/files/etc/rsyslog.d/untangle.conf
+++ b/untangle-system-config/files/etc/rsyslog.d/untangle.conf
@@ -28,6 +28,9 @@ $template DynFile,"/var/log/uvm/%SYSLOGTAG:F,58:1%.log"
 :syslogtag, startswith, "untangleclassd" -/var/log/untangle-classd/monitor.log
 & stop
 
+:syslogtag, startswith, "uvm" -/var/log/uvm/uvm.log
+& stop
+
 ## FIXME
 # the next 3 rules should ideally not be enabled at all when logs are
 # sent to a remote syslog instance, but at least the local* facilities
@@ -38,8 +41,8 @@ $template DynFile,"/var/log/uvm/%SYSLOGTAG:F,58:1%.log"
 # whatever behavior SyslogManagerImpl tries to specify will come too
 # late.
 
-if ($syslogfacility-text == 'local0') then -/var/log/uvm/uvm.log
-& stop
+# if ($syslogfacility-text == 'local0') then -/var/log/uvm/uvm.log
+# & stop
 
 # if ($syslogfacility-text == 'local1') then -/var/log/uvm/events.log
 # & stop


### PR DESCRIPTION
Updated untangle.conf file
Changed rule for logging uvm logs from
```
$outchannel oc_uvm.log,/var/log/uvm/uvm.log,524288000,/usr/share/untangle-system-config/syslog-maxsize-rotate.sh /var/log/uvm/uvm.log
if ($syslogfacility-text == 'local0') then :omfile:$oc_uvm.log & stop
```
to 

```
$outchannel oc_uvm.log,/var/log/uvm/uvm.log,524288000,/usr/share/untangle-system-config/syslog-maxsize-rotate.sh /var/log/uvm/uvm.log
:syslogtag, startswith, "uvm" :omfile:$oc_uvm.log & stop
```


Local Testing:

- Built the updated package `untangle-system-config` using command `PACKAGE=untangle-system-config FORCE=1 VERBOSE=1 UPLOAD=local docker compose -f docker-compose.build.yml run build`

- Installed the package on local NGFW
