### PR TITLE
ngfw-14673: Log4j Upgrade Enhancements: Analysis and implementation alternative of ThrowableRenderer

### DIFF
--- a/untangle-system-config/files/etc/rsyslog.d/untangle.conf
+++ b/untangle-system-config/files/etc/rsyslog.d/untangle.conf
@@ -4,6 +4,7 @@ $ModLoad imudp
 $UDPServerRun 514
 $FileCreateMode 0644
 
+$EscapeControlCharactersOnReceive off
 $template DynFile,"/var/log/uvm/%SYSLOGTAG:F,58:1%.log"
 
 :syslogtag, startswith, "app" -?DynFile


### PR DESCRIPTION
As per log4j2.x, instead of ThrowableRenderer Interface for exception log formatting LogEventPatternConverter class needs to be implemented.
 
 However syslog is converting new line to #012 , so logs are not properly formatted, they are logged in single line.
(https://stackoverflow.com/questions/24606757/rsyslogd-and-characters-012-and-015)(https://www.rsyslog.com/doc/configuration/input_directives/rsconf1_escapecontrolcharactersonreceive.html)

Refer the image
![image](https://github.com/untangle/ngfw_pkgs/assets/154513962/6bbcde02-a9b9-46bf-a5fd-1ef9812f3040)



Turning off the property.