### PR TITLE
ngfw-14764: Keep kernel messages in kern.log

### DIFF
--- a/untangle-system-config/files/etc/rsyslog.d/untangle.conf
+++ b/untangle-system-config/files/etc/rsyslog.d/untangle.conf
@@ -32,6 +32,9 @@ $template DynFile,"/var/log/uvm/%SYSLOGTAG:F,58:1%.log"
 :syslogtag, startswith, "uvm" -/var/log/uvm/uvm.log
 & stop
 
+:syslogtag, startswith, "kernel:" -/var/log/kern.log
+& stop
+
 ## FIXME
 # the next 3 rules should ideally not be enabled at all when logs are
 # sent to a remote syslog instance, but at least the local* facilities


### PR DESCRIPTION
Testing changes,
With these changes kernel logs should be logged in /var/log/kern.log. 
![image](https://github.com/user-attachments/assets/f9f4461a-fe17-4ab1-b6a8-eb2adece003a)

Logs will be as follows:
![image](https://github.com/user-attachments/assets/f2b72488-a9b9-465c-bf8c-64dc81c64c5a)
