### PR TITLE
NGFW-14865: Addedd WireGuard VPN Access Rule and Rule Condition on Public Cloud images

### DIFF
--- a/untangle-hardware-asus-ac88u/files/usr/share/untangle/conf/appliance-network-config.js
+++ b/untangle-hardware-asus-ac88u/files/usr/share/untangle/conf/appliance-network-config.js
@@ -506,6 +506,38 @@
                 "ruleId": 13
             },
             {
+                "blocked": false,
+                "conditions": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": [
+                        {
+                            "conditionType": "PROTOCOL",
+                            "invert": false,
+                            "javaClass": "com.untangle.uvm.network.FilterRuleCondition",
+                            "value": "UDP"
+                        },
+                        {
+                            "conditionType": "DST_PORT",
+                            "invert": false,
+                            "javaClass": "com.untangle.uvm.network.FilterRuleCondition",
+                            "value": "51820"
+                        },
+                        {
+                            "conditionType": "SRC_INTF",
+                            "invert": false,
+                            "javaClass": "com.untangle.uvm.network.FilterRuleCondition",
+                            "value": "wan"
+                        }
+                    ]
+                },
+                "description": "Allow WireGuard",
+                "enabled": true,
+                "ipv6Enabled": true,
+                "javaClass": "com.untangle.uvm.network.FilterRule",
+                "readOnly": true,
+                "ruleId": 21
+            },
+            {
                 "blocked": true,
                 "conditions": {
                     "javaClass": "java.util.LinkedList",
@@ -1015,6 +1047,32 @@
     "virtualInterfaces": {
         "javaClass": "java.util.LinkedList",
         "list": [
+            {
+                "configType": "DISABLED",
+                "interfaceId": 249,
+                "isVirtualInterface": true,
+                "isVlanInterface": false,
+                "isWan": false,
+                "isWirelessInterface": false,
+                "javaClass": "com.untangle.uvm.network.InterfaceSettings",
+                "name": "WireGuard VPN",
+                "v4Aliases": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": []
+                },
+                "v4ConfigType": "AUTO",
+                "v6Aliases": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": []
+                },
+                "v6ConfigType": "DISABLED",
+                "vrrpAliases": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": []
+                },
+                "wirelessMode": "AP",
+                "wirelessVisibility": 0
+            },
             {
                 "configType": "DISABLED",
                 "interfaceId": 250,

--- a/untangle-hardware-azure-byol/files/usr/share/untangle/conf/appliance-network-config.js
+++ b/untangle-hardware-azure-byol/files/usr/share/untangle/conf/appliance-network-config.js
@@ -595,6 +595,38 @@
                 "ruleId": 16
             },
             {
+                "blocked": false,
+                "conditions": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": [
+                        {
+                            "conditionType": "PROTOCOL",
+                            "invert": false,
+                            "javaClass": "com.untangle.uvm.network.FilterRuleCondition",
+                            "value": "UDP"
+                        },
+                        {
+                            "conditionType": "DST_PORT",
+                            "invert": false,
+                            "javaClass": "com.untangle.uvm.network.FilterRuleCondition",
+                            "value": "51820"
+                        },
+                        {
+                            "conditionType": "SRC_INTF",
+                            "invert": false,
+                            "javaClass": "com.untangle.uvm.network.FilterRuleCondition",
+                            "value": "wan"
+                        }
+                    ]
+                },
+                "description": "Allow WireGuard",
+                "enabled": true,
+                "ipv6Enabled": true,
+                "javaClass": "com.untangle.uvm.network.FilterRule",
+                "readOnly": true,
+                "ruleId": 21
+            },
+            {
                 "blocked": true,
                 "conditions": {
                     "javaClass": "java.util.LinkedList",
@@ -879,6 +911,32 @@
     "virtualInterfaces": {
         "javaClass": "java.util.LinkedList",
         "list": [
+            {
+                "configType": "DISABLED",
+                "interfaceId": 249,
+                "isVirtualInterface": true,
+                "isVlanInterface": false,
+                "isWan": false,
+                "isWirelessInterface": false,
+                "javaClass": "com.untangle.uvm.network.InterfaceSettings",
+                "name": "WireGuard VPN",
+                "v4Aliases": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": []
+                },
+                "v4ConfigType": "AUTO",
+                "v6Aliases": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": []
+                },
+                "v6ConfigType": "DISABLED",
+                "vrrpAliases": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": []
+                },
+                "wirelessMode": "AP",
+                "wirelessVisibility": 0
+            },
             {
                 "configType": "DISABLED",
                 "interfaceId": 250,

--- a/untangle-hardware-azure-payg/files/usr/share/untangle/conf/appliance-network-config.js
+++ b/untangle-hardware-azure-payg/files/usr/share/untangle/conf/appliance-network-config.js
@@ -595,6 +595,38 @@
                 "ruleId": 16
             },
             {
+                "blocked": false,
+                "conditions": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": [
+                        {
+                            "conditionType": "PROTOCOL",
+                            "invert": false,
+                            "javaClass": "com.untangle.uvm.network.FilterRuleCondition",
+                            "value": "UDP"
+                        },
+                        {
+                            "conditionType": "DST_PORT",
+                            "invert": false,
+                            "javaClass": "com.untangle.uvm.network.FilterRuleCondition",
+                            "value": "51820"
+                        },
+                        {
+                            "conditionType": "SRC_INTF",
+                            "invert": false,
+                            "javaClass": "com.untangle.uvm.network.FilterRuleCondition",
+                            "value": "wan"
+                        }
+                    ]
+                },
+                "description": "Allow WireGuard",
+                "enabled": true,
+                "ipv6Enabled": true,
+                "javaClass": "com.untangle.uvm.network.FilterRule",
+                "readOnly": true,
+                "ruleId": 21
+            },
+            {
                 "blocked": true,
                 "conditions": {
                     "javaClass": "java.util.LinkedList",
@@ -879,6 +911,32 @@
     "virtualInterfaces": {
         "javaClass": "java.util.LinkedList",
         "list": [
+            {
+                "configType": "DISABLED",
+                "interfaceId": 249,
+                "isVirtualInterface": true,
+                "isVlanInterface": false,
+                "isWan": false,
+                "isWirelessInterface": false,
+                "javaClass": "com.untangle.uvm.network.InterfaceSettings",
+                "name": "WireGuard VPN",
+                "v4Aliases": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": []
+                },
+                "v4ConfigType": "AUTO",
+                "v6Aliases": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": []
+                },
+                "v6ConfigType": "DISABLED",
+                "vrrpAliases": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": []
+                },
+                "wirelessMode": "AP",
+                "wirelessVisibility": 0
+            },
             {
                 "configType": "DISABLED",
                 "interfaceId": 250,

--- a/untangle-hardware-ec2-byol/files/usr/share/untangle/conf/appliance-network-config.js
+++ b/untangle-hardware-ec2-byol/files/usr/share/untangle/conf/appliance-network-config.js
@@ -595,6 +595,38 @@
                 "ruleId": 16
             },
             {
+                "blocked": false,
+                "conditions": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": [
+                        {
+                            "conditionType": "PROTOCOL",
+                            "invert": false,
+                            "javaClass": "com.untangle.uvm.network.FilterRuleCondition",
+                            "value": "UDP"
+                        },
+                        {
+                            "conditionType": "DST_PORT",
+                            "invert": false,
+                            "javaClass": "com.untangle.uvm.network.FilterRuleCondition",
+                            "value": "51820"
+                        },
+                        {
+                            "conditionType": "SRC_INTF",
+                            "invert": false,
+                            "javaClass": "com.untangle.uvm.network.FilterRuleCondition",
+                            "value": "wan"
+                        }
+                    ]
+                },
+                "description": "Allow WireGuard",
+                "enabled": true,
+                "ipv6Enabled": true,
+                "javaClass": "com.untangle.uvm.network.FilterRule",
+                "readOnly": true,
+                "ruleId": 21
+            },
+            {
                 "blocked": true,
                 "conditions": {
                     "javaClass": "java.util.LinkedList",
@@ -879,6 +911,32 @@
     "virtualInterfaces": {
         "javaClass": "java.util.LinkedList",
         "list": [
+            {
+                "configType": "DISABLED",
+                "interfaceId": 249,
+                "isVirtualInterface": true,
+                "isVlanInterface": false,
+                "isWan": false,
+                "isWirelessInterface": false,
+                "javaClass": "com.untangle.uvm.network.InterfaceSettings",
+                "name": "WireGuard VPN",
+                "v4Aliases": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": []
+                },
+                "v4ConfigType": "AUTO",
+                "v6Aliases": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": []
+                },
+                "v6ConfigType": "DISABLED",
+                "vrrpAliases": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": []
+                },
+                "wirelessMode": "AP",
+                "wirelessVisibility": 0
+            },
             {
                 "configType": "DISABLED",
                 "interfaceId": 250,

--- a/untangle-hardware-ec2-payg/files/usr/share/untangle/conf/appliance-network-config.js
+++ b/untangle-hardware-ec2-payg/files/usr/share/untangle/conf/appliance-network-config.js
@@ -595,6 +595,38 @@
                 "ruleId": 16
             },
             {
+                "blocked": false,
+                "conditions": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": [
+                        {
+                            "conditionType": "PROTOCOL",
+                            "invert": false,
+                            "javaClass": "com.untangle.uvm.network.FilterRuleCondition",
+                            "value": "UDP"
+                        },
+                        {
+                            "conditionType": "DST_PORT",
+                            "invert": false,
+                            "javaClass": "com.untangle.uvm.network.FilterRuleCondition",
+                            "value": "51820"
+                        },
+                        {
+                            "conditionType": "SRC_INTF",
+                            "invert": false,
+                            "javaClass": "com.untangle.uvm.network.FilterRuleCondition",
+                            "value": "wan"
+                        }
+                    ]
+                },
+                "description": "Allow WireGuard",
+                "enabled": true,
+                "ipv6Enabled": true,
+                "javaClass": "com.untangle.uvm.network.FilterRule",
+                "readOnly": true,
+                "ruleId": 21
+            },
+            {
                 "blocked": true,
                 "conditions": {
                     "javaClass": "java.util.LinkedList",
@@ -879,6 +911,32 @@
     "virtualInterfaces": {
         "javaClass": "java.util.LinkedList",
         "list": [
+            {
+                "configType": "DISABLED",
+                "interfaceId": 249,
+                "isVirtualInterface": true,
+                "isVlanInterface": false,
+                "isWan": false,
+                "isWirelessInterface": false,
+                "javaClass": "com.untangle.uvm.network.InterfaceSettings",
+                "name": "WireGuard VPN",
+                "v4Aliases": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": []
+                },
+                "v4ConfigType": "AUTO",
+                "v6Aliases": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": []
+                },
+                "v6ConfigType": "DISABLED",
+                "vrrpAliases": {
+                    "javaClass": "java.util.LinkedList",
+                    "list": []
+                },
+                "wirelessMode": "AP",
+                "wirelessVisibility": 0
+            },
             {
                 "configType": "DISABLED",
                 "interfaceId": 250,


### PR DESCRIPTION
**ISSUE:** 
On both AWS and Azure BYOL images with version 17.2 when you create a new instance it is missing the default WireGuard Access rule. Also you cannot see any WireGuard VPN interface in Rule conditions. 

**FIX:**
Added the default virtual interface and access rule for wiregurad VPN in cloud default network file.

**TEST:**

1. Create a new instance in either AWS or Azure
2.  Review the Access Rules and look for the Wireguard VPN rule, it should visible.
3.  Try to configure a rule that uses WireGuard VPN interface as either source or destination. 
4.  Review the default WireGuard NAT rules. It should visible.

![Screenshot from 2024-10-25 21-43-46](https://github.com/user-attachments/assets/48d90613-7306-4f0f-bd39-2a68d79725d3)
![Screenshot from 2024-10-25 21-42-28](https://github.com/user-attachments/assets/fc25fec8-645c-4a98-a229-9142eb49bf7d)
