### PR TITLE
phish blocker fresh install conf issue

### DIFF
--- a/untangle-clamav-config/debian/untangle-clamav-config.postinst
+++ b/untangle-clamav-config/debian/untangle-clamav-config.postinst
@@ -31,15 +31,16 @@ unsetOption() {
 }
 
 #for upgrades from >=17.3 clamav version is upgraded
-if dpkg --compare-versions "$oldVersion" ge 17.3~ ; then
 #Socket communication done by daemon-socket service, comment configuration in /etc/clamav/clamd.conf
-  unsetOption TCPAddr
-  unsetOption TCPSocket
-  unsetOption LocalSocket
-  mkdir -p  $CLAMAV_SOCKET_DIR
+unsetOption TCPAddr
+unsetOption TCPSocket
+
+
+unsetOption LocalSocket
+mkdir -p  $CLAMAV_SOCKET_DIR
 
 #Socket communication done by daemon-socket service, Adding configuration file for the same
-  if [[ ! -f $CLAMAV_SOCKET_DIR/override.conf ]]; then
+if [[ ! -f $CLAMAV_SOCKET_DIR/override.conf ]]; then
     touch "$CLAMAV_SOCKET_DIR/override.conf"
     cat <<EOL >> "$CLAMAV_SOCKET_DIR/override.conf"
 [Socket]
@@ -47,11 +48,11 @@ ListenStream=
 ListenStream=/run/clamav/clamd.ctl
 ListenStream=127.0.0.1:3310
 EOL
-  fi
-
-  #adding new systemd override file
-  systemctl daemon-reload
 fi
+
+#adding new systemd override file
+systemctl daemon-reload
+
 
 # options we need
 #setOption TCPAddr 127.0.0.1
@@ -60,7 +61,6 @@ setOption MaxFileSize 100M
 setOption StreamMaxLength 100M
 
 # disable clamav at startup (apps start as necessary)
-deb-systemd-helper disable clamav-daemon.service
 
 SERVICE_NAME="clamav-freshclam"
 IS_RUNNING="active (running)"
@@ -72,11 +72,15 @@ IS_RUNNING="active (running)"
 if systemctl is-active --quiet $SERVICE_NAME && \
       systemctl status $SERVICE_NAME | grep -q "$IS_RUNNING"; then
       systemctl stop clamav-freshclam.service
+      systemctl stop clamav-daemon.service
+      systemctl stop clamav-daemon.socket
       /usr/bin/freshclam --foreground=true
       systemctl start clamav-freshclam.service
+      systemctl start clamav-daemon.service
 else
       /usr/bin/freshclam --foreground=true
       deb-systemd-helper disable clamav-freshclam.service
+      deb-systemd-helper disable clamav-daemon.service
 fi
 
 


### PR DESCRIPTION
On fresh install LocalSocket is not getting commented hence 3310 clamav port is not up.
We dont need an version check as we are commnenting the old option in daemon service. This will be run only once, however in multiple runs comment would be recommented 