### PR TITLE
ngfw-14960 updated untangle domain references with arista domain.

### DIFF
--- a/untangle-geoip-database/files/etc/cron.monthly/geoip-update
+++ b/untangle-geoip-database/files/etc/cron.monthly/geoip-update
@@ -10,7 +10,7 @@
 #set -x
 
 # This is the URL where we download the database update tarball
-NETURL=https://downloads.untangle.com/download.php
+NETURL=https://downloads.edge.arista.com/download.php
 
 # This is the location for the temporary working copy we download
 TEMPFILE=/tmp/geoip-download.tar.gz

--- a/untangle-pyconnector/debian/untangle-pyconnector.default
+++ b/untangle-pyconnector/debian/untangle-pyconnector.default
@@ -2,7 +2,7 @@
 # Pyconnector options
 LOG_FILE="/var/log/pyconnector.log"
 DEBUG_LEVEL=1
-#DEFAULT_SERVER=cmd.untangle.com
-SERVER=cmd.untangle.com
+#DEFAULT_SERVER=cmd.edge.arista.com
+SERVER=cmd.edge.arista.com
 #DEFAULT_PORT=80,443,993,4443,587,995,8080,53
 PORT=80,443,993,4443,587,995,8080,53

--- a/untangle-pyconnector/files/usr/bin/pyconnector
+++ b/untangle-pyconnector/files/usr/bin/pyconnector
@@ -25,8 +25,8 @@ from ssl import SSLContext, TLSVersion
 import platform
 
 UNTANGLE_CMD_PORTS = [80, 443, 993, 4443, 587, 995, 8080, 53]
-UNTANGLE_CMD_SERVERS = ["cmd.untangle.com"]
-# UNTANGLE_CMD_SERVERS = ["dev-cmd.untangle.com"]
+UNTANGLE_CMD_SERVERS = ["cmd.edge.arista.com"]
+# UNTANGLE_CMD_SERVERS = ["dev-cmd.edge.arista.com"]
 RETRY_TIME_LONG = 10
 RETRY_TIME_SHORT = 5
 CERTS_FILE = '/tmp/pyconnector/certs.pem'

--- a/untangle-region-eu/files/usr/share/untangle/conf/uris_override.js
+++ b/untangle-region-eu/files/usr/share/untangle/conf/uris_override.js
@@ -1,78 +1,73 @@
 {
-    "dnsTestHost": "updates.untangle.com",
+    "dnsTestHost": "updates.edge.arista.com",
     "javaClass": "com.untangle.uvm.UriManagerSettings",
-    "tcpTestHost": "updates.untangle.com",
+    "tcpTestHost": "updates.edge.arista.com",
     "uriTranslations": {
         "javaClass": "java.util.LinkedList",
         "list": [
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "https://ids.untangle.com/suricatasignatures.tar.gz"
+                "uri": "https://ids.edge.arista.com/suricatasignatures.tar.gz"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "https://labs.untangle.com/Utility/v1/mac"
+                "uri": "https://labs.edge.arista.com/Utility/v1/mac"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "https://auth-relay.untangle.com/callback.php"
+                "uri": "https://auth-relay.edge.arista.com/callback.php"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "https://auth.untangle.com/v1/CheckTokenAccess"
+                "uri": "https://auth.edge.arista.com/v1/CheckTokenAccess"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "https://telemetry.untangle.com/ngfw/v1/infection"
+                "uri": "https://telemetry.edge.arista.com/ngfw/v1/infection"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "http://updates.untangle.com/"
+                "uri": "http://updates.edge.arista.com/"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "https://launchpad.edge.arista.com",
-                "host": "cmd-eu.untangle.com"
+                "uri": "https://launchpad.edge.arista.com"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "https://cmd.untangle.com/",
-                "host": "cmd-eu.untangle.com"
+                "uri": "https://cmd.edge.arista.com/"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "https://license.untangle.com/license.php"
+                "uri": "https://license.edge.arista.com/license.php"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "https://classify.untangle.com/v1/md5s"
+                "uri": "https://classify.edge.arista.com/v1/md5s"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "http://bd.untangle.com/"
+                "uri": "http://bd.edge.arista.com/"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "https://boxbackup.untangle.com/boxbackup/backup.php",
-                "host": "boxbackup-eu.untangle.com"
+                "uri": "https://boxbackup.edge.arista.com/boxbackup/backup.php"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "https://boxbackup.untangle.com/api/index.php",
-                "host": "boxbackup-eu.untangle.com"
+                "uri": "https://boxbackup.edge.arista.com/api/index.php"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "https://downloads.untangle.com/download.php"
+                "uri": "https://downloads.edge.arista.com/download.php"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "http://translations.untangle.com/"
+                "uri": "http://translations.edge.arista.com/"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "https://queue.untangle.com/",
-                "host": "queue-eu.untangle.com"
+                "uri": "https://queue.edge.arista.com/"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
@@ -81,7 +76,7 @@
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",
-                "uri": "https://supssh.untangle.com/"
+                "uri": "https://supssh.edge.arista.com/"
             },
             {
                 "javaClass": "com.untangle.uvm.UriTranslation",


### PR DESCRIPTION
**Changes:** Replaced references to untangle domains with Arista domain.
**Document:** [Servers and Domains](https://awakesecurity.atlassian.net/wiki/spaces/IT/pages/2830860307/Servers+Domains+Certificates+IPs)