### PR TITLE
Ngfw 15098 vue offline setup wizard no  able to save settings

### DIFF
--- a/untangle-vue-ui/source/src/components/setup/System.vue
+++ b/untangle-vue-ui/source/src/components/setup/System.vue
@@ -223,7 +223,6 @@
             await new Promise((resolve, reject) => {
               window.rpc.setup.setTimeZone((result, ex) => {
                 if (ex) {
-                  console.log('exception :', ex)
                   Util.handleException(ex)
                   reject(ex)
                 } else {
@@ -249,7 +248,6 @@
             window.rpc.setup.setAdminPassword(
               (result, ex) => {
                 if (ex) {
-                  console.log('exception :', ex)
                   Util.handleException(ex)
                   reject(ex)
                 } else {


### PR DESCRIPTION
**Description:**
During the Offline Setup Wizard, after setting the admin password and proceeding to the next screen, opening the setup in a new browser window and clicking the "Resume Setup" button prompts for the admin password. After successfully logging in via the popup and resuming the wizard, clicking the "Next" button (to save the settings) did not proceed as expected.

**Fix:**
The issue has been resolved. Clicking the "Next" button now correctly saves the network settings and moves to the next screen.