### PR TITLE
ngfw-15101-handling of session scenerio properly

### DIFF
--- a/untangle-vue-ui/source/src/components/setup/Interface.vue
+++ b/untangle-vue-ui/source/src/components/setup/Interface.vue
@@ -82,7 +82,7 @@
                 </v-row>
               </v-radio-group>
 
-              <v-radio column value="BRIDGED">
+              <v-radio value="BRIDGED">
                 <template #label>
                   <span class="font-weight-medium text-h6 mt-3">{{ $t('Transparent Bridge') }}</span>
                 </template>
@@ -243,7 +243,7 @@
         this.dialog = false
       },
       setConfigType(radio) {
-        if (radio.target.defaultValue === 'BRIDGED') {
+        if (radio === 'BRIDGED') {
           this.internal.configType = 'BRIDGED'
         } else {
           this.internal.configType = 'ADDRESSED'

--- a/untangle-vue-ui/source/src/components/setup/Internet.vue
+++ b/untangle-vue-ui/source/src/components/setup/Internet.vue
@@ -448,7 +448,7 @@
           const status = await this.rpcForAdmin.networkManager.getInterfaceStatus(this.wan.interfaceId)
           this.wanStatus = status
         } catch (error) {
-          this.alertDialog(`Unable to get WAN status : ${error.message || error}`)
+          Util.handleException(error)
         }
       },
 

--- a/untangle-vue-ui/source/src/components/setup/License.vue
+++ b/untangle-vue-ui/source/src/components/setup/License.vue
@@ -48,15 +48,17 @@
       const rpcResponseForSetup = Util.setRpcJsonrpc('setup')
       if (rpcResponseForSetup) {
         this.rpc = rpcResponseForSetup
-      } else {
-        this.alertDialog('RPC setup failed')
       }
-      const rpcResponseForAdmin = Util.setRpcJsonrpc('admin')
-      if (rpcResponseForAdmin) {
-        this.rpcForAdmin = rpcResponseForAdmin
-      } else {
-        this.alertDialog('RPC setup failed')
-      }
+      // else {
+      //   this.alertDialog('RPC setup failed')
+      // }
+      // const rpcResponseForAdmin = Util.setRpcJsonrpc('admin')
+      // if (rpcResponseForAdmin) {
+      //   this.rpcForAdmin = rpcResponseForAdmin
+      // }
+      // else {
+      //   this.alertDialog('RPC setup failed')
+      // }
     },
     methods: {
       ...mapActions('setup', ['setShowStep']),

--- a/untangle-vue-ui/source/src/components/setup/License.vue
+++ b/untangle-vue-ui/source/src/components/setup/License.vue
@@ -49,16 +49,6 @@
       if (rpcResponseForSetup) {
         this.rpc = rpcResponseForSetup
       }
-      // else {
-      //   this.alertDialog('RPC setup failed')
-      // }
-      // const rpcResponseForAdmin = Util.setRpcJsonrpc('admin')
-      // if (rpcResponseForAdmin) {
-      //   this.rpcForAdmin = rpcResponseForAdmin
-      // }
-      // else {
-      //   this.alertDialog('RPC setup failed')
-      // }
     },
     methods: {
       ...mapActions('setup', ['setShowStep']),

--- a/untangle-vue-ui/source/src/components/setup/Network.vue
+++ b/untangle-vue-ui/source/src/components/setup/Network.vue
@@ -311,7 +311,6 @@
         const networkSettings = await new Promise(resolve => {
           rpc?.networkManager?.getNetworkSettings((result, ex) => {
             if (ex) {
-              console.log('***eception inside autoRefreshInterfaces :', ex)
               Util.handleException('Unable to refresh the interfaces')
               resolve(null)
             } else {
@@ -319,7 +318,6 @@
             }
           })
         })
-        console.log('networkSettings inside Network :', networkSettings)
 
         const interfaces = []
 

--- a/untangle-vue-ui/source/src/components/setup/System.vue
+++ b/untangle-vue-ui/source/src/components/setup/System.vue
@@ -250,29 +250,25 @@
                 if (ex) {
                   Util.handleException(ex)
                   reject(ex)
-                } else {
-                  resolve(result)
+                  return
                 }
+                Util.authenticate(this.newPassword, (error, success) => {
+                  if (error || !success) {
+                    this.$vuntangle.toast.add(
+                      this.$t(`Authentication failed after password update: ${error || error.message}`),
+                    )
+                    reject(new Error('Authentication failed after password update.'))
+                  } else {
+                    resolve()
+                    this.showInterfaces = true
+                  }
+                })
               },
               this.newPassword,
               this.adminEmail,
               this.installType.value,
             )
-          })
-          // Authenticate the updated password
-          await new Promise((resolve, reject) => {
-            this.$store.commit('SET_LOADER', true)
-            Util.authenticate(this.newPassword, (error, success) => {
-              if (error || !success) {
-                this.$vuntangle.toast.add(
-                  this.$t(`Authentication failed after password update: ${error || error.message}`),
-                )
-                reject(new Error('Authentication failed after password update.'))
-              } else {
-                resolve()
-                this.showInterfaces = true
-              }
-            })
+            resolve()
           })
         } catch (error) {
           this.$store.commit('SET_LOADER', false) // Stop loader

--- a/untangle-vue-ui/source/src/components/setup/Wizard.vue
+++ b/untangle-vue-ui/source/src/components/setup/Wizard.vue
@@ -160,11 +160,11 @@
           // Only for local.
           return
         }
-        this.networkSettings = await new Promise(resolve => {
+        this.networkSettings = await new Promise((resolve, reject) => {
           this?.rpcForAdmin?.networkManager?.getNetworkSettings((result, ex) => {
             if (ex) {
               Util.handleException('Unable to refresh the interfaces')
-              resolve(null)
+              reject(ex)
             } else {
               resolve(result)
             }

--- a/untangle-vue-ui/source/src/components/setup/Wizard.vue
+++ b/untangle-vue-ui/source/src/components/setup/Wizard.vue
@@ -160,8 +160,17 @@
           // Only for local.
           return
         }
-        this.networkSettings = await this.rpcForAdmin?.networkManager?.getNetworkSettings()
-        this.interfaces = await this.networkSettings.interfaces.list
+        this.networkSettings = await new Promise(resolve => {
+          this?.rpcForAdmin?.networkManager?.getNetworkSettings((result, ex) => {
+            if (ex) {
+              Util.handleException('Unable to refresh the interfaces')
+              resolve(null)
+            } else {
+              resolve(result)
+            }
+          })
+        })
+        this.interfaces = this.networkSettings.interfaces.list
         const firstWan = this.interfaces.find(function (intf) {
           return intf.isWan && intf.configType !== 'DISABLED'
         })
@@ -216,7 +225,7 @@
           this.cardIndex--
           if (this.cardIndex >= 2) {
             this.$store.commit('SET_LOADER', true)
-            this.rpcForAdmin.networkManager.getNetworkSettings(async (result, ex) => {
+            this.rpcForAdmin?.networkManager?.getNetworkSettings(async (result, ex) => {
               if (ex) {
                 Util.handleException('Unable to load interfaces.')
                 return

--- a/untangle-vue-ui/source/src/util/setupUtil.js
+++ b/untangle-vue-ui/source/src/util/setupUtil.js
@@ -152,7 +152,7 @@ const Util = {
     }
 
     /** Handle Invalid Security Nonce (Session Expired) */
-    if (exception.code === 595 || exception.message.includes('Invalid security nonce')) {
+    if (exception.code === 595 || exception.message?.includes('Invalid security nonce')) {
       this.showWarningMessage(
         'Your session has expired due to a security issue. Please log in again.',
         details,
@@ -193,7 +193,11 @@ const Util = {
       )
       return
     }
-    this.showWarningMessage(exception.message || 'An unknown error occurred.', details, this.goToStartPage)
+    if (typeof exception === 'string') {
+      this.showWarningMessage(exception, '', this.goToStartPage)
+    } else {
+      this.showWarningMessage(exception.message || 'An unknown error occurred.', details, this.goToStartPage)
+    }
   },
 
   async showWarningMessage(message, details = '', errorHandler = null, buttonName = null) {


### PR DESCRIPTION
**Description :** 

After completing the admin password screen and opening /admin/index.do in a new browser tab,
then logging out and returning to the setup wizard, an error pop-up appears with a relevant message—similar to the behavior in Ext JS.
Once the pop-up is closed, the user is taken back to the initial setup wizard screen, just like in Ext JS.