### PR TITLE
window rpc object replace with setJsonRpc method

### DIFF
--- a/untangle-vue-ui/source/src/components/Reusable/RemapInterfaceDialogue.vue
+++ b/untangle-vue-ui/source/src/components/Reusable/RemapInterfaceDialogue.vue
@@ -129,7 +129,6 @@
         this.$emit('confirm', this.gridData)
       },
       async remapInterfaces() {
-        this.rpcForAdmin = Util.setRpcJsonrpc('admin')
         const physicalDevsStore = []
         this.intfOrderArr = []
         this.intfListLength = this.alert.parentInterfaces.length
@@ -145,7 +144,7 @@
         })
 
         const deviceRecords = await new Promise((resolve, reject) => {
-          this.rpcForAdmin.networkManager.getDeviceStatus((result, ex) => {
+          window.rpc.networkManager.getDeviceStatus((result, ex) => {
             if (ex) {
               Util.handleException(ex)
               reject(ex)

--- a/untangle-vue-ui/source/src/components/settings/network/Interface.vue
+++ b/untangle-vue-ui/source/src/components/settings/network/Interface.vue
@@ -352,7 +352,7 @@
     },
     async created() {
       try {
-        this.adminRpc = await Util.setRpcJsonrpc('admin')
+        this.adminRpc = await window.rpc
       } catch (ex) {
         Util.handleException(ex)
       }
@@ -454,7 +454,7 @@
       async loadSettings() {
         try {
           this.tableLoading.interfaces = true
-          const rpc = await Util.setRpcJsonrpc('admin')
+          const rpc = await window.rpc
 
           // Prepare promises for fetching data
           const networkSettingsPromise = await rpc.networkManager.getNetworkSettings()

--- a/untangle-vue-ui/source/src/components/settings/network/SettingsInterface/components/ipv4/Ipv4Dhcp.vue
+++ b/untangle-vue-ui/source/src/components/settings/network/SettingsInterface/components/ipv4/Ipv4Dhcp.vue
@@ -170,7 +170,7 @@
       interfaces: ({ $interfaces }) => $interfaces(),
     },
     async created() {
-      this.rpc = await Util.setRpcJsonrpc('admin')
+      this.rpc = await window.rpc
     },
 
     methods: {

--- a/untangle-vue-ui/source/src/components/settings/network/SettingsInterface/components/vrrp/Vrrp.vue
+++ b/untangle-vue-ui/source/src/components/settings/network/SettingsInterface/components/vrrp/Vrrp.vue
@@ -115,8 +115,7 @@
       async setVrrpmaster() {
         if (this.intf.vrrpEnabled && this.intf.interfaceId > 0) {
           try {
-            const rpc = Util.setRpcJsonrpc('admin')
-            this.vrrpmaster = await rpc.networkManager.isVrrpMaster(this.intf.interfaceId)
+            this.vrrpmaster = await window.rpc.networkManager.isVrrpMaster(this.intf.interfaceId)
           } catch (ex) {
             Util.handleException(ex)
           }

--- a/untangle-vue-ui/source/src/store/settings.js
+++ b/untangle-vue-ui/source/src/store/settings.js
@@ -32,8 +32,7 @@ const mutations = {
 const actions = {
   async getInterfaces({ commit }) {
     try {
-      const rpc = await Util.setRpcJsonrpc('admin')
-      const data = rpc.networkManager.getNetworkSettings().interfaces.list
+      const data = await window.rpc.networkManager.getNetworkSettings().interfaces.list
       const sortedData = await [...data].sort((a, b) => a.interfaceId - b.interfaceId)
       commit('SET_INTERFACES', sortedData)
     } catch (err) {
@@ -42,9 +41,8 @@ const actions = {
   },
   async getInterfaceStatuses({ commit }) {
     try {
-      const rpc = await Util.setRpcJsonrpc('admin')
-      const interfaces = rpc.networkManager.getNetworkSettings().interfaces.list
-      const intfStatusList = rpc.networkManager.getInterfaceStatus()
+      const interfaces = await window.rpc.networkManager.getNetworkSettings().interfaces.list
+      const intfStatusList = await window.rpc.networkManager.getInterfaceStatus()
       const interfaceWithStatus = interfaces.map(intf => {
         const status = intfStatusList.list.find(j => j.interfaceId === intf.interfaceId)
         return { ...intf, ...status }
@@ -57,8 +55,7 @@ const actions = {
   },
   async getNetworkSettings({ commit }) {
     try {
-      const rpc = await Util.setRpcJsonrpc('admin')
-      const data = rpc.networkManager.getNetworkSettings()
+      const data = await window.rpc.networkManager.getNetworkSettings()
       commit('SET_NETWORK_SETTINGS', data)
     } catch (err) {
       console.error('getNetworkSettings error:', err)
@@ -74,7 +71,6 @@ const actions = {
     try {
       if (Util.isDestroyed(this, updatedInterface)) return
 
-      const rpc = await Util.setRpcJsonrpc('admin')
       const settings = state.networkSetting
       const interfaces = Array.isArray(settings.interfaces) ? settings.interfaces : []
 
@@ -82,7 +78,7 @@ const actions = {
       //     // Handle new interface creation
       if (!updatedIntf) {
         const updatedInterfaces = [...interfaces, updatedInterface]
-        return await rpc.networkManager.setNetworkSettings({
+        return await window.rpc.networkManager.setNetworkSettings({
           ...settings,
           interfaces: {
             javaClass: 'java.util.LinkedList',
@@ -101,7 +97,7 @@ const actions = {
         }
       })
 
-      await rpc.networkManager.setNetworkSettings({
+      await window.rpc.networkManager.setNetworkSettings({
         ...settings,
         interfaces: {
           javaClass: 'java.util.LinkedList',
@@ -126,10 +122,9 @@ const actions = {
       if (Util.isDestroyed(this, interfaces)) {
         return
       }
-      const rpc = await Util.setRpcJsonrpc('admin')
       const settings = state.networkSetting
       settings.interfaces.list = interfaces
-      await rpc.networkManager.setNetworkSettings(settings)
+      await window.rpc.networkManager.setNetworkSettings(settings)
       vuntangle.toast.add('Successfully saved interface remapping.')
     } catch (ex) {
       vuntangle.toast.add('Rolling back settings to previous version.')
@@ -137,9 +132,8 @@ const actions = {
     }
   },
   // Delete selected Interface and update all interfaces
-  async deleteInterfaces({ state }, interfaces) {
+  deleteInterfaces({ state }, interfaces) {
     try {
-      const rpc = await Util.setRpcJsonrpc('admin')
       const fullSettings = JSON.parse(JSON.stringify(state.networkSetting))
 
       fullSettings.interfaces = {
@@ -151,7 +145,7 @@ const actions = {
       }
 
       return new Promise((resolve, reject) => {
-        rpc.networkManager.setNetworkSettings((response, exception) => {
+        window.rpc.networkManager.setNetworkSettings((response, exception) => {
           if (Util.isDestroyed(this)) return
 
           if (exception) {


### PR DESCRIPTION
-  setJsonRpc method is replaced with Window.rpc. 
- Window.rpc provide same object as we getting from setJsonRpc.
- Once you login then it maintain rpc global object and use all over the session.
- as admin logged in you can able to handled window.rpc object for api calls.