### PR TITLE
ngfw-15208: added logic to remove conflicting logrotate file

### DIFF
--- a/untangle-suricata-config/debian/untangle-suricata-config.postinst
+++ b/untangle-suricata-config/debian/untangle-suricata-config.postinst
@@ -14,6 +14,11 @@ fi
 systemctl --no-block stop suricata || true
 deb-systemd-helper disable suricata.service
 
+# Remove legacy or conflicting logrotate file if it exists
+if [ -f /etc/logrotate.d/suricata.log ]; then
+    rm -f /etc/logrotate.d/suricata.log
+fi
+
 # Override the suricata package logrotate config so as to avoid having .backup log files created
 # The /usr/share/untangle-suricata-config/logrotate.conf file is the same as the default suricata logrotate file
 # except it adds the delaycompress config item


### PR DESCRIPTION
**ISSUE:**
We are seeing below error logs while log rotate becuase in  /etc/logrotate.d/ one additional rotate file is getting generated . Need to analyize the scenario which generate extra rotate file.
> 
> May 18 00:00:47 untangle systemd[1]: Starting Rotate log files...
> May 18 00:00:48 untangle logrotate[24977]: error: suricata.log:1 duplicate log entry for /var/log/suricata/fast.log
> May 18 00:00:48 untangle logrotate[24977]: error: found error in file suricata.log, skipping

**RootCause:**
Based on the investigation, it was found that the conflicting file suricata.log is present on systems upgraded from versions older than 16.x.
In previous versions, the log rotation configuration used a file named suricata.log located in /etc/logrotate.d/. However, in the newer version (16.x and above), the configuration file is named suricata.
During the upgrade process, the old file (suricata.log) is not removed, resulting in a conflict. This causes the logrotate service to fail with the following error:
> 
> logrotate.service: Main process exited, code=exited, status=1/FAILURE systemd[1]: logrotate.service: Failed with result 'exit-> code'. logrotate[14541]: error: suricata.log:1 duplicate log entry for /var/log/suricata/*.log
> 

**Fix:**
Updated the logic to remove the unwanted rotate file which is causing conflict.