### PR TITLE
NGFW-15206 Setting API version for Ext (v1) and Vue (v2) calls

### DIFF
--- a/untangle-apache2-config/files/var/www/jsonrpc/jsonrpc.js
+++ b/untangle-apache2-config/files/var/www/jsonrpc/jsonrpc.js
@@ -25,6 +25,7 @@
  */
 
 var jsonRpcNonce = "";
+var apiVersion = "v1";
 
 /* escape a character */
 
@@ -738,11 +739,11 @@ JSONRpcClient.prototype._makeRequest = function (methodName, args, cb)
 
   if (this.objectID)
   {
-    obj += "\".obj#" + this.objectID + "." + methodName +"\"";
+    obj += "\".obj#" + this.objectID + "." + methodName + "." + apiVersion + "\"";
   }
   else
   {
-    obj += "\"" + methodName + "\"";
+    obj += "\"" + methodName + "." + apiVersion + "\"";
   }
 
   if (cb)

--- a/untangle-vue-ui/source/public/jsonrpc.js
+++ b/untangle-vue-ui/source/public/jsonrpc.js
@@ -25,6 +25,7 @@
  */
 
 var jsonRpcNonce = "";
+var apiVersion = "v2";
 
 /* escape a character */
 
@@ -738,11 +739,11 @@ JSONRpcClient.prototype._makeRequest = function (methodName, args, cb)
 
   if (this.objectID)
   {
-    obj += "\".obj#" + this.objectID + "." + methodName +"\"";
+    obj += "\".obj#" + this.objectID + "." + methodName + "." + apiVersion + "\"";
   }
   else
   {
-    obj += "\"" + methodName + "\"";
+    obj += "\"" + methodName + "." + apiVersion + "\"";
   }
 
   if (cb)


### PR DESCRIPTION
- We are now going to send API version in `method` param of JSON RPC calls.
- ExtJS calls would send v1 and Vue calls would send v2.
- This API version is used by jabsrob library https://github.com/AristaKB/jabsorb/pull/2 to set the marshalling mode which decides how JSON is to be serialized.
