### PR TITLE
ngfw-15228 Interfaces listing changes according to vuntangle

### DIFF
--- a/untangle-vue-ui/source/src/components/settings/network/Interface.vue
+++ b/untangle-vue-ui/source/src/components/settings/network/Interface.vue
@@ -52,13 +52,13 @@
         this.interfacesStatus = intfStatusList
       },
 
-      async getInterfaceArp(device, callback) {
-        if (!device) {
+      async getInterfaceArp(symbolicDev, callback) {
+        if (!symbolicDev) {
           this.arpEntriesData = []
           return
         }
 
-        const result = await Rpc.asyncData('rpc.networkManager.getStatus', 'INTERFACE_ARP_TABLE', device)
+        const result = await Rpc.asyncData('rpc.networkManager.getStatus', 'INTERFACE_ARP_TABLE', symbolicDev)
         const connections = []
         const macAddressList = []
 

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -3401,9 +3401,9 @@ electron-to-chromium@^1.5.149:
   integrity sha512-UWKi/EbBopgfFsc5k61wFpV7WrnnSlSzW/e2XcBmS6qKYTivZlLtoll5/rdqRTxGglGHkmkW0j0pFNJG10EUIQ==
 
 electron-to-chromium@^1.5.173:
-  version "1.5.186"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.186.tgz#b25af3a986f7a32f74ba2813461dcd3d9dc226bb"
-  integrity sha512-lur7L4BFklgepaJxj4DqPk7vKbTEl0pajNlg2QjE5shefmlmBLm2HvQ7PMf1R/GvlevT/581cop33/quQcfX3A==
+  version "1.5.187"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.187.tgz#8c58854e065962351dc87e95614dd78d50425966"
+  integrity sha512-cl5Jc9I0KGUoOoSbxvTywTa40uspGJt/BDBoDLoxJRSBpWh4FFXBsjNRHfQrONsV/OoEjDfHUmZQa2d6Ze4YgA==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -7901,8 +7901,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.58.77"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#a7921550a7de8128fd79b4a50413aa13ba88edc0"
+  version "1.58.80"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#ed60a8ace551fc198c23861eb73f5e0ec22b4623"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
- Implemented setWirelessIntfLogs and getArpData functions to call the API for ARP entries and Wi-Fi logs based on the device type.
- Passed these functions via emit as done in the vUntangle implementation.
- Added a new flag hasStatusTable to manage the UI display of Status and ARP Entries specifically for NGFW.
- Attached a screenshot as a UI reference for the integration.

<img width="1931" height="1030" alt="image" src="https://github.com/user-attachments/assets/f972b63e-fc31-49b3-bf3b-8d01534b3766" />
