### PR TITLE
NGFW-15191 untangle-hardware-config is now dependent on lm-sensors

### DIFF
--- a/untangle-hardware-config/debian/control
+++ b/untangle-hardware-config/debian/control
@@ -8,7 +8,7 @@ Standards-Version: 3.9.8
 
 Package: untangle-hardware-config
 Architecture: all
-Depends: ${misc:Depends}, systemd-sysv, mmc-utils
+Depends: ${misc:Depends}, systemd-sysv, mmc-utils, lm-sensors
 Description: The Untangle hardware config
  Provides the mechanism for other packages to register startup
  actions, to load hardware-related settings at boot time.


### PR DESCRIPTION
Since lm-sensors package is available in `current` distribution, we need to cherry-pick the hardware-config dependency change to master.
Cherry-picked from https://github.com/untangle/ngfw_pkgs/pull/210.