### PR TITLE
ngfw-15263 fixed renew dhcp Issue on configure internet/internet screen

### DIFF
--- a/untangle-vue-ui/source/src/components/setup/Internet.vue
+++ b/untangle-vue-ui/source/src/components/setup/Internet.vue
@@ -224,6 +224,8 @@
             if (defaultItem) {
               this.wan.v4StaticPrefix = defaultItem.value
             }
+          } else if (newVal.value) {
+            this.wan.v4StaticPrefix = newVal.value
           }
         },
       },

--- a/untangle-vue-ui/source/src/components/setup/Internet.vue
+++ b/untangle-vue-ui/source/src/components/setup/Internet.vue
@@ -219,10 +219,10 @@
       'wan.v4StaticPrefix': {
         immediate: true,
         handler(newVal) {
-          if (!newVal || newVal.value == null) {
+          if (!newVal) {
             const defaultItem = this.v4NetmaskList.find(item => item.value === 24)
             if (defaultItem) {
-              this.wan.v4StaticPrefix = defaultItem
+              this.wan.v4StaticPrefix = defaultItem.value
             }
           }
         },
@@ -356,6 +356,7 @@
       },
       async testConnectivity(testType, cb) {
         try {
+          console.log('***********')
           // build test fail message if any
           let message = ''
           let nextDisabled = true

--- a/untangle-vue-ui/source/src/components/setup/Internet.vue
+++ b/untangle-vue-ui/source/src/components/setup/Internet.vue
@@ -356,7 +356,6 @@
       },
       async testConnectivity(testType, cb) {
         try {
-          console.log('***********')
           // build test fail message if any
           let message = ''
           let nextDisabled = true


### PR DESCRIPTION
**Description:**

Clicking the Renew DHCP button on the Configure Internet screen results in an error: 
Unable to set network setting
The API response indicates a failure due to: UnmarshalException

**The issue has been fixed.**

Expected Behaviour:
Clicking Renew DHCP on the Internet screen should successfully trigger the renewDhcp API.
No error should occur.
Network settings should be updated successfully without failure.

