### PR TITLE
ngfw-15252 Changed solution to inject APP_VARIANT

### DIFF
--- a/untangle-vue-ui/source/src/App.vue
+++ b/untangle-vue-ui/source/src/App.vue
@@ -1,6 +1,5 @@
 <template>
   <div>
-    <AppVariantInjector />
     <blank-layout
       v-if="
         embedded ||
@@ -14,17 +13,11 @@
   </div>
 </template>
 <script>
-  import { AppVariantInjector } from 'vuntangle'
   import { BlankLayout, DefaultLayout } from '@/layouts'
 
   export default {
-    components: { DefaultLayout, BlankLayout, AppVariantInjector },
+    components: { DefaultLayout, BlankLayout },
 
-    provide() {
-      return {
-        APP_VARIANT: 'NGFW',
-      }
-    },
     data() {
       return {
         embedded: false,

--- a/untangle-vue-ui/source/vue.config.js
+++ b/untangle-vue-ui/source/vue.config.js
@@ -69,5 +69,11 @@ module.exports = {
       config.resolve.alias.set('vue-i18n', path.resolve('./node_modules/vue-i18n'))
       config.resolve.alias.set('vuetify', path.resolve('./node_modules/vuetify'))
     }
+
+    // Define APP_VARIANT for global access
+    config.plugin('define').tap(args => {
+      args[0]['process.env'].APP_VARIANT = JSON.stringify('NGFW')
+      return args
+    })
   },
 }

--- a/vue-ui-build-push.sh
+++ b/vue-ui-build-push.sh
@@ -31,7 +31,7 @@ echo ">>> Step 7: Run docker compose build"
 PACKAGE=untangle-vue-ui FORCE=1 VERBOSE=1 UPLOAD=local docker compose -f docker-compose-ngfw-ui-build.yml run build
 
 echo ">>> Step 8: Verify .deb package was created"
-DEB_FILE=$(ls untangle-vue-ui_17.4.0*.deb 2>/dev/null || true)
+DEB_FILE=$(ls untangle-vue-ui_*.deb 2>/dev/null || true)
 
 if [ -z "$DEB_FILE" ]; then
     echo "ERROR: No .deb file was generated."
@@ -44,7 +44,7 @@ echo ">>> Step 9: SCP .deb to remote server"
 scp "$DEB_FILE" root@ngfw.untangle.com:/tmp/
 
 echo ">>> Step 10: Install .deb and reboot remote server (combined)"
-ssh root@ngfw.untangle.com "dpkg -i /tmp/untangle-vue-ui_17.4.0*.deb && reboot"
+ssh root@ngfw.untangle.com "dpkg -i /tmp/untangle-vue-ui_*.deb && reboot"
 
 
 echo ">>> DONE — Remote system is rebooting"


### PR DESCRIPTION
We had introduced `app-variant.js` with a variable `APP_VARIANT`. Default value if this variable is `MFW`. This is used to conditionally handle `vuntangle` code for NGFW and MFW.

We noticed that setting `APP_VARIANT` does not work when in config related `.js` file. However if used from **vue components** file then it works.

- Changed the solution to inject the APP_VARIANT
Now the value is injected at build time by the parent repo via `chainWebpack`
Its executed at build time so before loading the .js files we have value in `vuntangle`

- Modified `vue-ui-build-push.sh`  to support all versions for local build


