### PR TITLE
ngfw-15266 added null check for type and interface specific status API integration

### DIFF
--- a/untangle-vue-ui/source/src/components/settings/network/InterfaceEdit.vue
+++ b/untangle-vue-ui/source/src/components/settings/network/InterfaceEdit.vue
@@ -76,8 +76,7 @@
         try {
           let interfaceId
           if (this.intfSetting?.device === device) interfaceId = this.intfSetting?.interfaceId
-          else interfaceId = this.interfaces.find(intf => intf.device === device)?.interfaceId
-          interfaceId = undefined
+          else interfaceId = this.interfaces?.find(intf => intf.device === device)?.interfaceId
           if (interfaceId) {
             await window.rpc.networkManager.renewDhcpLease(interfaceId)
             await this.getInterfaceStatus()

--- a/untangle-vue-ui/source/src/components/settings/network/InterfaceEdit.vue
+++ b/untangle-vue-ui/source/src/components/settings/network/InterfaceEdit.vue
@@ -55,11 +55,6 @@
       if (this.device) {
         await this.getInterfaceStatus()
       }
-      // set the help context for this device type (e.g. interfaces_wwan)
-      const type = this.type || this.intfSetting?.type
-      if (type) {
-        this.$store.commit('SET_HELP_CONTEXT', `interfaces_${type.toLowerCase()}`)
-      }
     },
     methods: {
       // get the interface status


### PR DESCRIPTION
On the vue UI clicking on `Back To List` button on Edit interface page was sometimes throwing an error.

- Removed error causing code `(HelpContext)` as its not required now for NGFW
- Integrated the interface specific `getinterfaceStatusV2` API which accepts device as param and returns `status` response
- Refactored `getInterfaceStatus` and `onRenewDhcp` code.