### PR TITLE
Ngfw 15267 refactor store and interfaces

### DIFF
--- a/untangle-vue-ui/source/src/components/settings/interface/DeleteInterfaceDialog.vue
+++ b/untangle-vue-ui/source/src/components/settings/interface/DeleteInterfaceDialog.vue
@@ -1,14 +1,27 @@
 <template>
   <v-card flat class="ma-0 text--secondary">
-    <h4 v-if="!affectedChildInterfaces.length" v-html="$t('delete_interface_confirm', [intf.name])" />
+    <h4 v-if="!affectedInterfaces.length" v-html="$t('delete_interface_confirm', [intf.name])" />
+
+    <!-- bridged interfaces -->
+    <div v-if="affectedInterfaces.length" class="mb-4">
+      <p class="ma-0 font-weight-medium">
+        {{ $t('following_interfaces_have_this_as_bridged_to') }}
+      </p>
+      <ul>
+        <li v-for="iface in affectedInterfaces" :key="iface">
+          <span v-html="$t('interface_is_bridged_to', [iface, intf.name])" />
+        </li>
+      </ul>
+    </div>
   </v-card>
 </template>
 <script>
   export default {
     props: {
       intf: { type: Object, default: () => null },
-      affectedChildInterfaces: { type: Array, default: () => [] },
+      affectedInterfaces: { type: Array, default: () => [] },
     },
+
     methods: {
       async action() {
         this.$emit('progress-show')

--- a/untangle-vue-ui/source/src/components/settings/network/Interface.vue
+++ b/untangle-vue-ui/source/src/components/settings/network/Interface.vue
@@ -54,8 +54,7 @@
         this.$store.commit('SET_LOADER', true)
         this.interfacesStatus = await new Promise((resolve, reject) =>
           window.rpc.networkManager.getAllInterfacesStatusV2((res, err) => (err ? reject(err) : resolve(res))),
-        )
-        this.$store.commit('SET_LOADER', false)
+        ).finally(() => this.$store.commit('SET_LOADER', false))
       },
 
       /**
@@ -127,10 +126,9 @@
         callback?.(this.wirelessLogs)
       },
 
-      onRefresh() {
+      async onRefresh() {
         this.$store.commit('SET_LOADER', true)
-        this.$store.dispatch('settings/getInterfaces')
-        this.$store.commit('SET_LOADER', false)
+        await this.$store.dispatch('settings/getInterfaces').finally(() => this.$store.commit('SET_LOADER', false))
         this.getInterfacesStatus()
       },
 

--- a/untangle-vue-ui/source/src/components/settings/network/Interface.vue
+++ b/untangle-vue-ui/source/src/components/settings/network/Interface.vue
@@ -4,6 +4,7 @@
     :interfaces-status="interfacesStatus"
     :features="features"
     @refresh="onRefresh"
+    @refresh-status="onInterfaceStatusRefresh"
     @add-interface="onAddInterface"
     @edit-interface="onEditInterface"
     @delete-interface="onDelete"
@@ -13,12 +14,13 @@
 </template>
 <script>
   import { Interfaces } from 'vuntangle'
+  import settingsMixin from '../settingsMixin'
   import interfaceMixin from './interfaceMixin'
   import Rpc from '@/util/Rpc'
 
   export default {
     components: { Interfaces },
-    mixins: [interfaceMixin],
+    mixins: [interfaceMixin, settingsMixin],
     data: () => ({
       // all interfaces status, async fetched
       interfacesStatus: undefined,
@@ -34,13 +36,13 @@
 
     computed: {
       // interfaces filered and grouped (by category)
-      interfaces() {
-        return this.$store.getters['settings/networkSetting'].interfaces
+      interfaces({ $store }) {
+        return $store.getters['settings/networkSetting'].interfaces
       },
     },
 
     created() {
-      this.$store.dispatch('settings/getNetworkSettings') // update interfaces in the store
+      this.$store.dispatch('settings/getNetworkSettings')
     },
 
     mounted() {
@@ -49,10 +51,20 @@
 
     methods: {
       async getInterfacesStatus() {
-        const intfStatusList = await window.rpc.networkManager.getAllInterfacesStatusV2()
-        this.interfacesStatus = intfStatusList
+        this.$store.commit('SET_LOADER', true)
+        this.interfacesStatus = await new Promise((resolve, reject) =>
+          window.rpc.networkManager.getAllInterfacesStatusV2((res, err) => (err ? reject(err) : resolve(res))),
+        )
+        this.$store.commit('SET_LOADER', false)
       },
 
+      /**
+       * Fetches ARP entries for the given symbolic device.
+       * If no device is provided, clears the arpEntriesData.
+       *
+       * @param {string} symbolicDev - The symbolic device identifier.
+       * @param {function} callback - Optional callback to handle the result.
+       */
       async getInterfaceArp(symbolicDev, callback) {
         if (!symbolicDev) {
           this.arpEntriesData = []
@@ -104,6 +116,7 @@
         this.arpEntriesData = connections
         callback?.(connections) // Send back result
       },
+
       async setWirelessIntfLogs(intfc, callback) {
         if (intfc.type === 'WIFI') {
           this.wirelessLogs = await window.rpc.networkManager.getLogFile(intfc.device)
@@ -117,8 +130,22 @@
       onRefresh() {
         this.$store.commit('SET_LOADER', true)
         this.$store.dispatch('settings/getInterfaces')
-        this.getInterfacesStatus()
         this.$store.commit('SET_LOADER', false)
+        this.getInterfacesStatus()
+      },
+
+      async onInterfaceStatusRefresh(device) {
+        if (!device) return
+
+        const result = await new Promise((resolve, reject) => {
+          window.rpc.networkManager.getInterfaceStatusV2((res, err) => (err ? reject(err) : resolve(res)), device)
+        })
+        this.interfacesStatus = this.interfacesStatus.map(intf => {
+          if (intf.device === device) {
+            return { ...intf, ...result }
+          }
+          return intf
+        })
       },
 
       /**
@@ -149,6 +176,14 @@
         if (intf) {
           this.deleteInterfaceHandler(intf)
         }
+      },
+
+      /**
+       * Optional hook triggered on browser refresh.
+       * Fetches updated network settings and updates the store.
+       */
+      onBrowserRefresh() {
+        this.$store.dispatch('settings/getNetworkSettings', true)
       },
     },
   }

--- a/untangle-vue-ui/source/src/components/settings/settingsMixin.js
+++ b/untangle-vue-ui/source/src/components/settings/settingsMixin.js
@@ -1,6 +1,8 @@
 import cloneDeep from 'lodash/cloneDeep'
 import isEqual from 'lodash/isEqual'
 
+let reloaded = false
+
 export default {
   props: {
     settings: { type: [Object, Array], default: null },
@@ -51,5 +53,16 @@ export default {
     onUndo() {
       this.settingsCopy = cloneDeep(this.settings)
     },
+  },
+
+  /**
+   * Lifecycle hook to detect browser reload.
+   * If a reload is detected, calls the `onBrowserRefresh` method.
+   */
+  beforeMount() {
+    if (!reloaded) {
+      reloaded = true
+      this.onBrowserRefresh?.()
+    }
   },
 }

--- a/untangle-vue-ui/source/src/store/settings.js
+++ b/untangle-vue-ui/source/src/store/settings.js
@@ -14,7 +14,7 @@ const getters = {
   networkSetting: state => state.networkSetting || [],
   interfaces: state => state?.networkSetting?.interfaces || [],
   interface: state => device => {
-    return state.networkSetting.interfaces.find(intf => intf.device === device)
+    return state.networkSetting?.interfaces?.find(intf => intf.device === device)
   },
 }
 
@@ -35,8 +35,11 @@ const actions = {
       console.error('getInterfaces error:', err)
     }
   },
-  async getNetworkSettings({ commit }) {
+  async getNetworkSettings({ state, commit }, refetch) {
     try {
+      if (state.networkSetting && !refetch) {
+        return
+      }
       const data = await window.rpc.networkManager.getNetworkSettingsV2()
       commit('SET_NETWORK_SETTINGS', data)
     } catch (err) {


### PR DESCRIPTION
**Changes:**

- Not allowing interface deletion for bridged to affected interfaces.
- Refactored store methods
- Added on browser refresh hook
- Added `onInterfaceStatusRefresh` event listener for fetching interface specific status response
- Added loader for get network settings and get status API's