### PR TITLE
NGFW-15299 rsyslog configuration for daemon.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,9 @@ debootstrap.log
 *.buildinfo
 .pybuild
 *.egg-info
+*.deb
+*.debian.tar.xz
+*.orig.tar.xz
+*.dsc
+*.changes
+*.upload

--- a/untangle-system-config/files/etc/rsyslog.d/untangle.conf
+++ b/untangle-system-config/files/etc/rsyslog.d/untangle.conf
@@ -35,6 +35,9 @@ $template DynFile,"/var/log/uvm/%SYSLOGTAG:F,58:1%.log"
 :syslogtag, startswith, "kernel:" -/var/log/kern.log
 & stop
 
+daemon.* -/var/log/daemon.log
+& stop
+
 ## FIXME
 # the next 3 rules should ideally not be enabled at all when logs are
 # sent to a remote syslog instance, but at least the local* facilities


### PR DESCRIPTION
- daemon logs are now sent to `/var/log/daemon.log`. With this configuration, rsyslog will take care of size log rotation too.
- ipsec/charon logs will only be logged in `/var/log/ipsec.log`. Those logs won't land in either daemon.log or syslog files.