### PR TITLE
ngfw-15661 bugfix for setup wizard issue

### DIFF
--- a/untangle-vue-ui/source/src/components/setup/License.vue
+++ b/untangle-vue-ui/source/src/components/setup/License.vue
@@ -38,12 +38,14 @@
     data: () => ({
       remoteEulaSrc: null,
     }),
-    mounted() {
-      this.setEulaSrc()
-    },
     computed: {
       ...mapGetters('setup', ['wizardSteps', 'currentStep', 'previousStep']),
     },
+
+    mounted() {
+      this.setEulaSrc()
+    },
+
     created() {
       const rpcResponseForSetup = Util.setRpcJsonrpc('setup')
       if (rpcResponseForSetup) {
@@ -55,7 +57,7 @@
       ...mapActions('setup', ['setShowPreviousStep']),
 
       async setEulaSrc() {
-        this.remoteEulaSrc = await uris.translate(uris.list.legal)
+        this.remoteEulaSrc = await uris.list.legal
       },
 
       async onContinue() {

--- a/untangle-vue-ui/source/src/store/apps.js
+++ b/untangle-vue-ui/source/src/store/apps.js
@@ -27,8 +27,14 @@ const mutations = {
 }
 
 const actions = {
-  getApp(context, appName) {
-    return window.rpc.appManager.app(appName)
+  getApp(_, appName) {
+    try {
+      const app = window.rpc.appManager.app(appName)
+      return app
+    } catch (err) {
+      Util.handleException(err)
+      return null
+    }
   },
 
   async getAppSettings({ dispatch }, appName) {

--- a/untangle-vue-ui/source/src/util/setupUtil.js
+++ b/untangle-vue-ui/source/src/util/setupUtil.js
@@ -128,7 +128,7 @@ const Util = {
     const adminRpc = this.setRpcJsonrpc('admin')
     if (!rpc.wizardSettings.wizardComplete) {
       rpc.wizardSettings.completedStep = step
-      if (adminRpc.jsonrpc.UvmContext) {
+      if (adminRpc?.jsonrpc?.UvmContext) {
         await adminRpc.jsonrpc.UvmContext.setWizardSettings(rpc.wizardSettings)
       }
     }

--- a/untangle-vue-ui/source/src/util/uris.js
+++ b/untangle-vue-ui/source/src/util/uris.js
@@ -1,22 +1,3 @@
-import http from '@/plugins/http'
-
-/**
- * return translated URI if found otherwise fallsback to the original URI
- * uses http instead of api, so it avoids displaying UI toast errors
- * @returns {string} - translated uri
- */
-async function translate(uri) {
-  let response
-  try {
-    response = await http.get(`/api/uri/geturiwithpath/uri=${uri}`)
-  } catch (ex) {
-    // return the initial uri passed to translation
-    return uri
-  }
-  // return translated or original uri
-  return response?.data || uri
-}
-
 const list = {
   feedback: 'https://aristamicroedge.featureupvote.com/',
   help: 'https://support.untangle.com/hc/en-us/categories/360001799354',
@@ -31,5 +12,4 @@ const list = {
 
 export default {
   list,
-  translate,
 }


### PR DESCRIPTION
**Description:**

Fixed the console error that occurred when clicking Disagree on the License page during the Setup Wizard, where the page did not navigate back to the Welcome page as expected.

Also removed the legal API call from the License tab, as it was not a valid API call and was causing a 404 Not Found console error.

Fixed lint issue.