### PR TITLE
Ngfw 15663 virus blocker app Status and Settings tab impl

### DIFF
--- a/untangle-vue-ui/source/src/components/Apps/apps/VirusBlocker/VirusBlocker.vue
+++ b/untangle-vue-ui/source/src/components/Apps/apps/VirusBlocker/VirusBlocker.vue
@@ -27,9 +27,7 @@
   export default {
     name: 'VirusBlockerApp',
 
-    components: {
-      VirusBlocker,
-    },
+    components: { VirusBlocker },
 
     mixins: [appMixin],
 
@@ -46,14 +44,11 @@
     },
 
     computed: {
-      /**
-       * Application display name
-       */
+      // Display name for the app, falling back to a default if not provided in appData.
       appDisplayName: ({ appData }) => appData?.appProperties?.displayName || 'Virus Blocker',
 
-      /**
-       * Consolidates app data with powerState and virus-blocker specific extra data
-       */
+      // Consolidated app data to pass to the VirusBlocker component,
+      // including additional properties for file scanner availability and last signature update.
       consolidatedAppData: ({ appData, powerState, lastSignatureUpdate, isFileScannerAvailable }) => {
         return {
           ...appData,
@@ -65,9 +60,7 @@
     },
 
     watch: {
-      /**
-       * Once appManager is available (set by appMixin.created), fetch virus-blocker specific data.
-       */
+      // Watcher for appManager from appMixin to trigger fetching of virus-blocker specific data when the manager becomes available.
       appManager: {
         async handler(manager) {
           if (!manager) return
@@ -78,8 +71,8 @@
 
     methods: {
       /**
-       * Fetches virus-blocker specific data: file scanner availability and last signature update.
-       * Uses appManager from appMixin.
+       * Fetches virus-blocker specific data such as file scanner availability and last signature update time from the app manager.
+       * This method is called when the appManager becomes available, and updates the component's data properties accordingly.
        */
       async fetchVirusBlockerData() {
         if (!this.appManager) return
@@ -95,6 +88,15 @@
 
         this.isFileScannerAvailable = isAvailable
         this.lastSignatureUpdate = lastUpdate
+      },
+
+      /**
+       * Refreshes the app data by calling the refreshData method from appMixin and then fetching the latest virus-blocker specific data.
+       * This method is triggered when the user clicks the "Refresh" button in the UI, ensuring that all displayed information is up to date.
+       */
+      refreshData() {
+        appMixin.methods.refreshData.call(this)
+        this.fetchVirusBlockerData()
       },
     },
   }

--- a/untangle-vue-ui/source/src/components/Apps/apps/VirusBlocker/VirusBlocker.vue
+++ b/untangle-vue-ui/source/src/components/Apps/apps/VirusBlocker/VirusBlocker.vue
@@ -1,0 +1,101 @@
+<template>
+  <virus-blocker
+    :settings="settings"
+    :app-data="consolidatedAppData"
+    :sessions-data="sessionsData"
+    :metrics-data="formattedMetrics"
+    :reports="appReports"
+    @toggle-state="toggleAppState"
+    @remove-app="removeApp"
+  >
+    <!-- Custom action buttons slot -->
+    <template #actions="{ newSettings, isDirty }">
+      <u-btn class="mr-2" @click="refreshData">
+        {{ $t('refresh') }}
+      </u-btn>
+      <u-btn :disabled="!isDirty || saveDisabled" @click="saveSettings(newSettings)">
+        {{ $t('save') }}
+      </u-btn>
+    </template>
+  </virus-blocker>
+</template>
+
+<script>
+  import { VirusBlocker } from 'vuntangle'
+  import appMixin from '../appMixin'
+
+  export default {
+    name: 'VirusBlockerApp',
+
+    components: {
+      VirusBlocker,
+    },
+
+    mixins: [appMixin],
+
+    props: {
+      appData: { type: Object, default: null },
+    },
+
+    data() {
+      return {
+        appName: this.appData?.appName || 'virus-blocker',
+        isFileScannerAvailable: false,
+        lastSignatureUpdate: null,
+      }
+    },
+
+    computed: {
+      /**
+       * Application display name
+       */
+      appDisplayName: ({ appData }) => appData?.appProperties?.displayName || 'Virus Blocker',
+
+      /**
+       * Consolidates app data with powerState and virus-blocker specific extra data
+       */
+      consolidatedAppData: ({ appData, powerState, lastSignatureUpdate, isFileScannerAvailable }) => {
+        return {
+          ...appData,
+          isFileScannerAvailable,
+          lastSignatureUpdate,
+          powerState: powerState || {},
+        }
+      },
+    },
+
+    watch: {
+      /**
+       * Once appManager is available (set by appMixin.created), fetch virus-blocker specific data.
+       */
+      appManager: {
+        async handler(manager) {
+          if (!manager) return
+          await this.fetchVirusBlockerData()
+        },
+      },
+    },
+
+    methods: {
+      /**
+       * Fetches virus-blocker specific data: file scanner availability and last signature update.
+       * Uses appManager from appMixin.
+       */
+      async fetchVirusBlockerData() {
+        if (!this.appManager) return
+
+        const [isAvailable, lastUpdate] = await Promise.all([
+          new Promise(resolve => {
+            this.appManager.isFileScannerAvailable((res, ex) => resolve(ex ? false : res))
+          }),
+          new Promise(resolve => {
+            this.appManager.getLastSignatureUpdate((res, ex) => resolve(ex ? null : res))
+          }),
+        ])
+
+        this.isFileScannerAvailable = isAvailable
+        this.lastSignatureUpdate = lastUpdate
+      },
+    },
+  }
+</script>

--- a/untangle-vue-ui/source/src/components/Apps/apps/VirusBlocker/index.js
+++ b/untangle-vue-ui/source/src/components/Apps/apps/VirusBlocker/index.js
@@ -1,0 +1,1 @@
+export { default } from './VirusBlocker.vue'

--- a/untangle-vue-ui/source/src/components/Apps/apps/appMixin.js
+++ b/untangle-vue-ui/source/src/components/Apps/apps/appMixin.js
@@ -10,6 +10,7 @@ export default {
       appManager: null, // Cached app manager instance for RPC calls
       toggling: false, // Local state to track if app is currently toggling (starting/stopping)
       saveDisabled: false, // Flag to disable save button on settings error
+      sessionHistory: this.initializeSessionsData(), // Rolling 7-point history for the sessions chart
     }
   },
 
@@ -28,7 +29,7 @@ export default {
    * to reduce code duplication and ensure consistent behavior across app components.
    */
   computed: {
-    ...mapGetters('metrics', ['getFormattedMetrics', 'getLiveSessions']),
+    ...mapGetters('metrics', ['getFormattedMetrics', 'getLiveSessions', 'lastUpdateTime']),
     ...mapGetters('apps', ['getAppPowerState']),
 
     /**
@@ -98,32 +99,45 @@ export default {
     formattedMetrics: ({ instanceId, getFormattedMetrics }) => (instanceId ? getFormattedMetrics(instanceId) : []),
 
     /**
-     * Sessions chart data from Vuex store
-     * Returns initial empty data if instanceId not available
+     * Sessions chart data — returns the rolling 7-point history maintained by the watcher.
+     * Falls back to the zero-initialized baseline when the app is off or instanceId is unavailable.
      */
     sessionsData() {
       if (!this.powerState?.on) return []
-      // If instanceId not available yet, return initialized sessions data with zeros to populate chart baseline
-      if (!this.instanceId) {
-        return this.initializeSessionsData()
-      }
-      const liveSessions = this.getLiveSessions(this.instanceId)
-      // Build rolling window with current value
-      const now = Date.now()
-      const data = []
-
-      for (let i = -6; i <= 0; i++) {
-        data.push({
-          timestamp: now + i * 10000,
-          sessions: i === 0 ? liveSessions : 0,
-        })
-      }
-
-      return data
+      if (!this.instanceId) return this.initializeSessionsData()
+      return this.sessionHistory
     },
 
     settings: ({ $store, appData }) =>
       $store.getters['apps/getSettings'](`${appData?.appName}-${appData?.instance?.id}`)?.settings || {},
+  },
+
+  watch: {
+    /**
+     * Fires on every poll tick (lastUpdateTime advances even when sessions value is unchanged),
+     * ensuring the x-axis timestamp always moves forward.
+     */
+    lastUpdateTime(timestamp) {
+      if (!this.powerState?.on || !this.instanceId) return
+
+      const sessions = this.getLiveSessions(this.instanceId)
+
+      if (this.sessionHistory.length === 0) {
+        const init = this.initializeSessionsData()
+        init[init.length - 1].sessions = sessions
+        this.sessionHistory = init
+        return
+      }
+
+      this.sessionHistory = [...this.sessionHistory.slice(1), { timestamp, sessions }]
+    },
+
+    /**
+     * Clear history when the app is turned off so the chart resets on next start.
+     */
+    'powerState.on'(isOn) {
+      if (!isOn) this.sessionHistory = this.initializeSessionsData()
+    },
   },
 
   async created() {

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -342,12 +342,12 @@
     "@babel/types" "^7.27.1"
 
 "@babel/helpers@^7.28.6":
-  version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.28.6.tgz#fca903a313ae675617936e8998b814c415cbf5d7"
-  integrity sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.29.2.tgz#9cfbccb02b8e229892c0b07038052cc1a8709c49"
+  integrity sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==
   dependencies:
     "@babel/template" "^7.28.6"
-    "@babel/types" "^7.28.6"
+    "@babel/types" "^7.29.0"
 
 "@babel/highlight@^7.10.4":
   version "7.25.9"
@@ -388,9 +388,9 @@
     "@babel/types" "^7.28.5"
 
 "@babel/parser@^7.28.6", "@babel/parser@^7.29.0":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.0.tgz#669ef345add7d057e92b7ed15f0bac07611831b6"
-  integrity sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.2.tgz#58bd50b9a7951d134988a1ae177a35ef9a703ba1"
+  integrity sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==
   dependencies:
     "@babel/types" "^7.29.0"
 
@@ -2617,9 +2617,9 @@ base@^0.11.1:
     pascalcase "^0.1.1"
 
 baseline-browser-mapping@^2.9.0:
-  version "2.10.8"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.8.tgz#23d1cea1a85b181c2b8660b6cfe626dc2fb15630"
-  integrity sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==
+  version "2.10.10"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.10.tgz#e74bd066724c1d8d7d8ea75fc3be25389a7a5c56"
+  integrity sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==
 
 batch-processor@1.0.0:
   version "1.0.0"
@@ -2825,9 +2825,9 @@ caniuse-lite@^1.0.30001726:
   integrity sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==
 
 caniuse-lite@^1.0.30001759:
-  version "1.0.30001779"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001779.tgz#75e4941d406928ba00c8d7a3ddda0b2cb90d7474"
-  integrity sha512-U5og2PN7V4DMgF50YPNtnZJGWVLFjjsN3zb6uMT5VGYIewieDj1upwfuVNXf4Kor+89c3iCRJnSzMD5LmTvsfA==
+  version "1.0.30001781"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz#344b47c03eb8168b79c3c158b872bcfbdd02a400"
+  integrity sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"
@@ -3591,9 +3591,9 @@ electron-to-chromium@^1.5.173:
   integrity sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==
 
 electron-to-chromium@^1.5.263:
-  version "1.5.313"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.313.tgz#193e9ae2c2ab6915acb41e833068381e4ef0b3e4"
-  integrity sha512-QBMrTWEf00GXZmJyx2lbYD45jpI3TUFnNIzJ5BBc8piGUDwMPa1GV6HJWTZVvY/eiN3fSopl7NRbgGp9sZ9LTA==
+  version "1.5.321"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.321.tgz#57a80554e2e7fd65e3689d320f52a64723472d5d"
+  integrity sha512-L2C7Q279W2D/J4PLZLk7sebOILDSWos7bMsMNN06rK482umHUrh/3lM8G7IlHFOYip2oAg5nha1rCMxr/rs6ZQ==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -8127,8 +8127,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.61.12"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#cae7f1484be2d54235e58f568b66083abf11db14"
+  version "1.61.20"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#4e5c307eeab21429890b2a7b511a42d606773aee"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
Implementation of Status and Settings tabs for Virus Blocker Application.
`Scan Options` and `Pass Sites` extjs tabs merged into single `Settings` tab.

Modified live sessions data logic to get the real time live sessions. Keeping old time stamp sessions in `sessionHistory`

--------------
<img width="1840" height="1140" alt="Screenshot from 2026-03-23 11-11-08" src="https://github.com/user-attachments/assets/c16043a6-4fc5-41ad-a75d-03063eb67af0" />

--------------
<img width="1840" height="1140" alt="Screenshot from 2026-03-23 11-10-59" src="https://github.com/user-attachments/assets/d38ab348-5a9e-489c-ab05-bce7e5648964" />

--------------
<img width="1840" height="1140" alt="Screenshot from 2026-03-23 11-11-32" src="https://github.com/user-attachments/assets/2788f35b-a052-4097-9991-253e5e1b5cdf" />

--------------
