### PR TITLE
ngfw-15671 email template grid implementation

### DIFF
--- a/untangle-vue-ui/source/src/components/settings/services/Reports.vue
+++ b/untangle-vue-ui/source/src/components/settings/services/Reports.vue
@@ -1,12 +1,22 @@
 <template>
   <v-container fluid :class="`shared-cmp d-flex flex-column flex-grow-1 pa-0`">
-    <reports-app :settings="settings" @save-settings="onSaveSettings" @refresh-settings="loadAppData" />
+    <reports-app
+      :settings="settings"
+      :report-queue-size="reportQueueSize"
+      :get-server-time="fetchServerTime"
+      :server-tz-offset="serverTzOffset"
+      @save-settings="onSaveSettings"
+      @refresh-settings="loadAppData"
+      @run-fixed-report="onRunFixedReport"
+    />
   </v-container>
 </template>
 
 <script>
   import { ReportsApp } from 'vuntangle'
   import serviceMixin from './serviceMixin'
+  import Rpc from '@/util/Rpc'
+  import util from '@/util/util'
 
   export default {
     components: {
@@ -19,6 +29,7 @@
         /* This is used to fetch the application's settings from the Vuex store. */
         appName: 'reports',
         licenseNodeName: 'reports',
+        reportQueueSize: 0,
       }
     },
 
@@ -33,13 +44,28 @@
 
       /* Gets the expert mode status from the settings */
       isExpertMode: ({ $store }) => $store.getters['config/isExpertMode'],
+
+      /* Server timezone offset in ms for date picker initialization */
+      serverTzOffset: ({ $store }) => $store.getters['config/timeZoneOffset'],
     },
 
     created() {
       this.loadAppData()
+      this.pollQueueSize()
+      this.$store.dispatch('config/getTimeZoneOffSet')
+    },
+
+    /* clear poll timer on component destroy to prevent memory leaks */
+    beforeDestroy() {
+      if (this._queuePollTimer) {
+        clearTimeout(this._queuePollTimer)
+        this._queuePollTimer = null
+      }
     },
 
     methods: {
+      /* returns current server time in ms */
+      fetchServerTime: () => util.getMilliseconds(),
       /* Load application data */
       loadAppData() {
         this.$store.dispatch('apps/loadAppData', { appName: this.appName })
@@ -57,8 +83,54 @@
             appName: this.appName,
             settings: newSettings,
           })
+        } catch {
+          // When online access is enabled without a password, the backend rejects the save and
+          // the error dialog is shown via Util.handleException in the store action. Without this
+          // catch, the rejected promise breaks the UI via DefaultLayout.errorCaptured.
         } finally {
           this.$store.commit('SET_LOADER', false)
+        }
+      },
+
+      /**
+       * Run a fixed report for the given template and date range,
+       * then fetch the queue size and start polling until the queue drains.
+       */
+      async onRunFixedReport({ templateId, startDate, stopDate }) {
+        this.$store.commit('SET_LOADER', true)
+        try {
+          const { success } = await this.$store.dispatch('apps/runFixedReport', { templateId, startDate, stopDate })
+          if (success) {
+            this.reportQueueSize = await this.fetchQueueSize()
+            this.startQueuePolling()
+          }
+        } finally {
+          this.$store.commit('SET_LOADER', false)
+        }
+      },
+
+      /** Start a 5-second poll loop if one is not already running. */
+      startQueuePolling() {
+        if (this._queuePollTimer) return
+        this._queuePollTimer = setTimeout(() => this.pollQueueSize(), 5000)
+      },
+
+      /** Fetch the current fixed report queue size from the app manager. */
+      async fetchQueueSize() {
+        const appManager = await Rpc.asyncData('rpc.appManager.app', 'reports')
+        return Rpc.asyncData(appManager, 'getFixedReportQueueSize')
+      },
+
+      /** Poll the queue size every 5 seconds until it reaches 0. */
+      async pollQueueSize() {
+        this._queuePollTimer = null
+        try {
+          this.reportQueueSize = await this.fetchQueueSize()
+          if (this.reportQueueSize > 0) {
+            this._queuePollTimer = setTimeout(() => this.pollQueueSize(), 5000)
+          }
+        } catch {
+          this.reportQueueSize = 0
         }
       },
     },

--- a/untangle-vue-ui/source/src/store/apps.js
+++ b/untangle-vue-ui/source/src/store/apps.js
@@ -699,6 +699,22 @@ const actions = {
   },
 
   /**
+   * Run a fixed report for the given template and date range.
+   * @param {Object} payload - { templateId, startDate, stopDate }
+   * @returns {Promise<{ success: boolean }>}
+   */
+  async runFixedReport(_, { templateId, startDate, stopDate }) {
+    try {
+      const appManager = await Rpc.asyncData('rpc.appManager.app', 'reports')
+      await Rpc.asyncData(appManager, 'runFixedReport', templateId, startDate, stopDate)
+      return { success: true }
+    } catch (err) {
+      Util.handleException(err)
+      return { success: false }
+    }
+  },
+
+  /**
    * Check license status for a specific license node
    * @param {Object} context - Vuex context
    * @param {String} licenseNodeName - The license node name to check

--- a/untangle-vue-ui/source/src/util/util.js
+++ b/untangle-vue-ui/source/src/util/util.js
@@ -37,6 +37,17 @@ const util = {
     }
   },
 
+  // returns milliseconds depending of the servlet ADMIN or REPORTS
+  getMilliseconds() {
+    if (window.rpc?.systemManager) {
+      return Rpc.directData('rpc.systemManager.getMilliseconds')
+    }
+    if (window.rpc?.ReportsContext) {
+      return Rpc.directData('rpc.ReportsContext.getMilliseconds')
+    }
+    return Date.now()
+  },
+
   /**
    * checks if box is reachable while rebooting or upgrading
    * using a 3s interval to avoid flooding with calls


### PR DESCRIPTION
Description :
- Added onSaveSettings — added catch for handles backend rejection (e.g. online access without password)
- Added onRunFixedReport — triggers a fixed report run for a given template and date range via apps/runFixedReport dispatch
- Added fetchQueueSize — fetches current fixed report queue size via getFixedReportQueueSize
- Added startQueuePolling / pollQueueSize — polls queue size every 5 seconds until it drains to 0
- Added fetchServerTime — provides current server time in ms to the Reports App component
- Added serverTzOffset — passes server timezone offset  for date picker initialisation
- beforeDestroy clears the poll timer to prevent memory leaks
- UI for reference 
<img width="1895" height="1019" alt="image" src="https://github.com/user-attachments/assets/298e54ff-b096-4bb2-8074-021225079592" />
<img width="1895" height="1019" alt="image" src="https://github.com/user-attachments/assets/524ac17a-eef9-4c98-9b49-2662577a0a0b" />
