### PR TITLE
ngfw-15686 email template api changes

### DIFF
--- a/untangle-vue-ui/source/src/components/settings/services/Reports.vue
+++ b/untangle-vue-ui/source/src/components/settings/services/Reports.vue
@@ -5,6 +5,9 @@
       :report-queue-size="reportQueueSize"
       :get-server-time="fetchServerTime"
       :server-tz-offset="serverTzOffset"
+      :get-recommended-report-ids="fetchRecommendedReportIds"
+      :get-current-applications="fetchCurrentApplications"
+      :get-fixed-reports-allow-graphs="fetchFixedReportsAllowGraphs"
       @save-settings="onSaveSettings"
       @refresh-settings="loadAppData"
       @run-fixed-report="onRunFixedReport"
@@ -66,6 +69,32 @@
     methods: {
       /* returns current server time in ms */
       fetchServerTime: () => util.getMilliseconds(),
+
+      /* fetches the reports manager instance via the reports app */
+      async fetchReportsManager() {
+        const reportsApp = await Rpc.asyncData('rpc.appManager.app', 'reports')
+        return Rpc.asyncData(reportsApp, 'getReportsManager')
+      },
+
+      /* returns list of recommended report IDs from the reports manager */
+      async fetchRecommendedReportIds() {
+        const reportsManager = await this.fetchReportsManager()
+        const result = await Rpc.asyncData(reportsManager, 'getRecommendedReportIds')
+        return result?.list || []
+      },
+
+      /* returns list of currently active applications from the reports manager */
+      async fetchCurrentApplications() {
+        const reportsManager = await this.fetchReportsManager()
+        const result = await Rpc.asyncData(reportsManager, 'getCurrentApplications')
+        return result?.list || []
+      },
+
+      /* returns whether fixed reports are allowed to display graphs */
+      async fetchFixedReportsAllowGraphs() {
+        const reportsManager = await this.fetchReportsManager()
+        return Rpc.asyncData(reportsManager, 'fixedReportsAllowGraphs')
+      },
       /* Load application data */
       loadAppData() {
         this.$store.dispatch('apps/loadAppData', { appName: this.appName })


### PR DESCRIPTION
Description:
- Added three new props to the reports component: `get-recommended-report-ids,` `get-current-applications`, and `get-fixed-reports-allow-graphs`
- Introduced `fetchReportsManager` as a shared RPC helper to retrieve the reports manager instance
- Added `fetchRecommendedReportIds`, `fetchCurrentApplications`, and `fetchFixedReportsAllowGraphs` methods to fetch report-related data.
- UI for reference 
<img width="1905" height="1028" alt="image" src="https://github.com/user-attachments/assets/982dde16-87f8-4e2b-a850-c5f49a2b64b5" />
