### PR TITLE
Ngfw 15696 service apps install uninstall

### DIFF
--- a/untangle-vue-ui/source/src/components/settings/services/DynamicBlockLists.vue
+++ b/untangle-vue-ui/source/src/components/settings/services/DynamicBlockLists.vue
@@ -1,6 +1,6 @@
 <template>
   <v-container fluid :class="`shared-cmp d-flex flex-column flex-grow-1 pa-2`">
-    <no-license v-if="isLicensed === false" class="mt-2">
+    <no-license v-if="isLicensed === false && isInstalled" class="mt-2">
       {{ $t('not_licensed_service', [$t('dynamic_blocklist')]) }}
       <template #actions>
         <u-btn class="ml-4" to="/settings/system/about">{{ $t('view_system_license') }}</u-btn>
@@ -12,10 +12,10 @@
     </no-license>
 
     <settings-dynamic-block-lists
-      v-if="dynamicListsSettings"
       :settings="dynamicListsSettings"
       :status="status"
-      :disabled="!isLicensed"
+      :disabled="!isLicensed && isInstalled"
+      :is-installed="isInstalled"
       @update-settings="onSave"
       @delete-configuration="onDeleteConfiguration"
       @download="onDownload"
@@ -23,19 +23,28 @@
       @download-csv="initiateDownload"
     >
       <template #actions="{ newSettings, disabled, isDirty }">
-        <u-btn :disabled="disabled" class="mr-2" @click="onResetDefaults">
-          {{ $vuntangle.$t('reset_to_defaults') }}
-        </u-btn>
-        <u-btn :disabled="disabled || !isDirty" @click="onSave(newSettings)">
-          {{ $vuntangle.$t('save') }}
-        </u-btn>
+        <div v-if="isInstalled" class="d-flex flex-wrap align-center" style="gap: 8px">
+          <div style="min-width: 180px">
+            <u-app-status-remove class="mt-0" service-app app-name="Dynamic Block Lists" @remove="onRemoveService" />
+          </div>
+          <v-divider vertical class="mx-4" />
+          <u-btn :disabled="disabled" @click="onResetDefaults">
+            {{ $vuntangle.$t('reset_to_defaults') }}
+          </u-btn>
+          <u-btn :disabled="disabled || !isDirty" @click="onSave(newSettings)">
+            {{ $vuntangle.$t('save') }}
+          </u-btn>
+        </div>
+        <div v-else style="min-width: 180px">
+          <u-app-install @install="onInstallService" />
+        </div>
       </template>
     </settings-dynamic-block-lists>
   </v-container>
 </template>
 
 <script>
-  import { SettingsDynamicBlockLists, NoLicense } from 'vuntangle'
+  import { SettingsDynamicBlockLists, NoLicense, UAppStatusRemove, UAppInstall } from 'vuntangle'
   import serviceMixin from './serviceMixin'
   import vuntangle from '@/plugins/vuntangle'
   import { EVENT_ACTIONS } from '@/constants/actions'
@@ -45,10 +54,13 @@
     components: {
       SettingsDynamicBlockLists,
       NoLicense,
+      UAppStatusRemove,
+      UAppInstall,
     },
     mixins: [serviceMixin],
     data() {
       return {
+        serviceName: 'dynamic-blocklists',
         licenseNodeName: 'dynamic-blocklists',
         status: [],
       }
@@ -69,6 +81,7 @@
        * formats the timestamp of each configuration to human readabale values
        */
       async fetchStatus() {
+        if (!this.isInstalled) return
         this.$store.commit('SET_LOADER', true)
         try {
           const response = await window.rpc.appManager.app('dynamic-blocklists').status()

--- a/untangle-vue-ui/source/src/components/settings/services/DynamicBlockLists.vue
+++ b/untangle-vue-ui/source/src/components/settings/services/DynamicBlockLists.vue
@@ -71,7 +71,7 @@
     computed: {
       dynamicListsSettings: ({ $store }) => $store.getters['apps/getSettings']('dynamic-blocklists')?.settings,
 
-      appDisplayName: ({ appManager }) => appManager?.getAppProperties?.()?.displayName || 'Dynamic Block Lists',
+      appDisplayName: ({ appManager }) => appManager?.getAppProperties?.()?.displayName || 'Dynamic Blocklists',
 
       consolidatedAppData: ({ powerState, appDisplayName }) => ({
         powerState: powerState || {},

--- a/untangle-vue-ui/source/src/components/settings/services/serviceMixin.js
+++ b/untangle-vue-ui/source/src/components/settings/services/serviceMixin.js
@@ -78,8 +78,7 @@ export default {
   async created() {
     this.checkLicense()
     this.getManageLicenseUri()
-    const app = await this.$store.dispatch('apps/getApp', { appName: this.licenseNodeName })
-    this.appManager = app || null
+    await this.setAppManager()
     if (this.hasAppSettings) {
       this.loadAppSettings()
     }
@@ -94,6 +93,15 @@ export default {
      */
     refreshData() {
       this.loadAppSettings()
+    },
+
+    /**
+     * Fetches the app manager instance for the licensed app and stores it in the component's state.
+     * This allows the component to interact with the app manager for operations like starting/stopping the app and fetching settings.
+     */
+    async setAppManager() {
+      const app = await this.$store.dispatch('apps/getApp', { appName: this.licenseNodeName })
+      this.appManager = app || null
     },
 
     /**
@@ -218,8 +226,10 @@ export default {
       this.$store.commit('SET_LOADER', true)
       try {
         await this.$store.dispatch('apps/installApp', { appName: this.serviceName })
-        await this.$store.dispatch('apps/loadAppData', { appName: this.licenseNodeName })
+        await this.setAppManager()
         await this.checkLicense()
+        await this.$store.dispatch('apps/loadAppData', { appName: this.licenseNodeName })
+        await this.$store.dispatch('reports/loadReports')
       } finally {
         this.$store.commit('SET_LOADER', false)
       }

--- a/untangle-vue-ui/source/src/components/settings/services/serviceMixin.js
+++ b/untangle-vue-ui/source/src/components/settings/services/serviceMixin.js
@@ -1,10 +1,25 @@
 import uris from '@/util/uris'
+import { EVENT_ACTIONS } from '@/constants/actions'
+import { sendEvent } from '@/utils/event'
+
 export default {
+  inject: ['embedded'],
+
   data() {
     return {
       isLicensed: undefined,
       manageLicenseUri: undefined,
     }
+  },
+
+  computed: {
+    // Get the apps view for the selected policy from the store
+    appsViewByPolicy: ({ $store }) => $store.getters['apps/getAppsViewByPolicy'](1),
+
+    // Determine if the app is currently installed based on the apps view for the selected policy
+    isInstalled() {
+      return this.appsViewByPolicy?.instances?.some(i => i.appName === this.serviceName) ?? undefined
+    },
   },
   created() {
     this.checkLicense()
@@ -43,6 +58,41 @@ export default {
      */
     isDaemonRunning(daemonName) {
       return this.$store.dispatch('apps/checkDaemonStatus', daemonName)
+    },
+
+    /** Installs the dynamic-blocklists app */
+    async onInstallService() {
+      this.$store.commit('SET_LOADER', true)
+      try {
+        await this.$store.dispatch('apps/installApp', { appName: this.serviceName })
+        await this.$store.dispatch('apps/loadAppData', { appName: this.licenseNodeName })
+        await this.checkLicense()
+      } finally {
+        this.$store.commit('SET_LOADER', false)
+      }
+    },
+
+    /**
+     * Handles the removal of the service app. It first sets a loader state to true, then finds the app instance
+     * corresponding to the serviceName in the current policy's apps view. It dispatches an action to destroy the app instance,
+     * and if the component is embedded, it sends an event to the parent indicating that the app has been removed. Finally, it sets the loader state back to false.
+     */
+    async onRemoveService() {
+      this.$store.commit('SET_LOADER', true)
+      try {
+        const instance = this.appsViewByPolicy?.instances?.find(i => i.appName === this.serviceName)
+        await this.$store.dispatch('apps/destroyApp', {
+          instanceId: instance?.id,
+          policyId: 1,
+        })
+        if (this.embedded) {
+          // If embedded, just send event to parent
+          // TODO Remove this once all apps are migrated to Vue UI and Parent Layout is changed
+          sendEvent({ type: EVENT_ACTIONS.REMOVE_APP, appName: this.serviceName })
+        }
+      } finally {
+        this.$store.commit('SET_LOADER', false)
+      }
     },
   },
 }

--- a/untangle-vue-ui/source/src/router/index.js
+++ b/untangle-vue-ui/source/src/router/index.js
@@ -100,8 +100,10 @@ router.beforeEach((to, from, next) => {
     // Session module is NOT persisted, so it resets on every page load/hard refresh
     // This ensures RPC calls run on every session start
     // But skips re-initialization during route navigation within same session
-    const isAdminRoute =
-      to.name && !to.name.includes('setup') && !to.name.includes('login') && !to.name.includes('wizard')
+    const nonAdminSegments = ['setup', 'login', 'wizard']
+    const isAdminRoute = !nonAdminSegments.some(
+      segment => to.name?.includes(segment) || to.path?.startsWith(`/${segment}`),
+    )
 
     if (isAdminRoute) {
       // Initialize admin context (loads apps, policy-manager, reports)

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -2617,9 +2617,9 @@ base@^0.11.1:
     pascalcase "^0.1.1"
 
 baseline-browser-mapping@^2.10.12:
-  version "2.10.17"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz#435c101835c314c2d89d768795e1ea79941fafd3"
-  integrity sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==
+  version "2.10.18"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.18.tgz#565745085ba7743af7d4072707ad132db3a5a42f"
+  integrity sha512-VSnGQAOLtP5mib/DPyg2/t+Tlv65NTBz83BJBJvmLVHHuKJVaDOBvJJykiT5TR++em5nfAySPccDZDa4oSrn8A==
 
 batch-processor@1.0.0:
   version "1.0.0"
@@ -2687,9 +2687,9 @@ boolbase@^1.0.0:
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 brace-expansion@^1.1.7:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.13.tgz#d37875c01dc9eff988dd49d112a57cb67b54efe6"
-  integrity sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==
+  version "1.1.14"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.14.tgz#d9de602370d91347cd9ddad1224d4fd701eb348b"
+  integrity sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -3591,9 +3591,9 @@ electron-to-chromium@^1.5.173:
   integrity sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==
 
 electron-to-chromium@^1.5.328:
-  version "1.5.334"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.334.tgz#1e3fdd8d014852104eb8e632e760fb364db7dd0e"
-  integrity sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==
+  version "1.5.335"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz#0b957cea44ef86795c227c616d16b4803d119daa"
+  integrity sha512-q9n5T4BR4Xwa2cwbrwcsDJtHD/enpQ5S1xF1IAtdqf5AAgqDFmR/aakqH3ChFdqd/QXJhS3rnnXFtexU7rax6Q==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -6871,10 +6871,11 @@ resolve@^1.1.6, resolve@^1.22.10:
     supports-preserve-symlinks-flag "^1.0.0"
 
 resolve@^1.10.0, resolve@^1.10.1:
-  version "1.22.11"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.11.tgz#aad857ce1ffb8bfa9b0b1ac29f1156383f68c262"
-  integrity sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==
+  version "1.22.12"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.12.tgz#f5b2a680897c69c238a13cd16b15671f8b73549f"
+  integrity sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==
   dependencies:
+    es-errors "^1.3.0"
     is-core-module "^2.16.1"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
@@ -8159,8 +8160,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.61.34"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#0496d3c104cd1b7623e88821877e7fef5321d052"
+  version "1.61.36"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#c9c14592bcaf601daa33f8d983a7f74f9e611527"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
## Summary

Implements install and uninstall flows for the Dynamic Block Lists (DBL) service app.
Users can install DBL when it is not present and uninstall it as a troubleshooting step.
The UI reflects the updated state immediately after install — no hard refresh required.

## Changes

**`serviceMixin.js`**
- Added `appsViewByPolicy` computed — reads installed/installable state from the Vuex `apps` store for policy ID 1
- Added `isInstalled` computed — checks if the service appears in `appsViewByPolicy.instances` by `serviceName`
- Added `appReports` computed — filters the global reports store by `appDisplayName` category and formats entries for the UI
- Added `onInstallService()`:
  - Installs the app via `apps/installApp`
  - Reloads app data and checks license
  - Fetches and sets `appManager` so `appDisplayName` resolves to the real backend display name (required for correct report category lookup)
  - Reloads reports — reports populate immediately after install without a hard refresh
- Added `onRemoveService()`:
  - Finds the app instance by `serviceName` in `appsViewByPolicy`
  - Dispatches `apps/destroyApp` with instance ID
  - Sends `REMOVE_APP` event to parent window when running in embedded mode

**`DynamicBlockLists.vue`**
- **Not installed state** — passes `:is-installed="isInstalled"` to the vuntangle component; only title, description, and Install button are visible
- **Installed state** — full settings grid with Remove button (`service-app` prop set for service-specific confirm message), Reset to Defaults, and Save
- **Unlicensed state** — shows `NoLicense` alert with links to the About page and license management portal when the app is installed but unlicensed
- Passes `consolidatedAppData` (power state + display name) and `appReports` to the vuntangle component for status and reports rendering