### PR TITLE
Ngfw 15721 implement captive portal Status and Rules Tab

### DIFF
--- a/untangle-vue-ui/source/src/components/Apps/apps/CaptivePortal/CaptivePortal.vue
+++ b/untangle-vue-ui/source/src/components/Apps/apps/CaptivePortal/CaptivePortal.vue
@@ -28,6 +28,7 @@
   import { CaptivePortal, UAppStatusRemove } from 'vuntangle'
   import { VDivider } from 'vuetify/lib'
   import appMixin from '../appMixin'
+  import util from '@/util/util'
 
   export default {
     name: 'CaptivePortalApp',
@@ -38,6 +39,17 @@
 
     props: {
       appData: { type: Object, default: null },
+    },
+
+    provide() {
+      return {
+        $remoteData: () => ({
+          interfaces: this.interfaces,
+        }),
+        $features: {},
+        $readOnly: false,
+        $applications: {},
+      }
     },
 
     data() {
@@ -56,6 +68,22 @@
           powerState: powerState || {},
         }
       },
+
+      // the network settings from the store
+      networkSettings: ({ $store }) => $store.getters['config/networkSetting'],
+
+      /**
+       * returns the interfaces for condition value from network settings
+       * @param {Object} vm.networkSettings
+       */
+      interfaces: ({ networkSettings }) => {
+        return util.getInterfaceList(networkSettings, true, true)
+      },
+    },
+
+    // Fetch the required settings when the component is created
+    created() {
+      this.fetchRequiredSettings(false)
     },
 
     watch: {
@@ -104,12 +132,22 @@
       },
 
       /**
+       * Fetches the required settings for the app, e.g. the network settings.
+       * This method can be called with a parameter to indicate whether to refetch the network settings from the store.
+       * @param {boolean} networkRefetch - Indicates whether to refetch the network settings from the store.
+       */
+      fetchRequiredSettings(networkRefetch) {
+        this.$store.dispatch('config/getNetworkSettings', networkRefetch)
+      },
+
+      /**
        * Overrides the refreshData method from appMixin to also refresh the active users list when the main app data is refreshed.
        * This ensures that the UI reflects the most up-to-date information about active users whenever a refresh is triggered.
        */
       refreshData() {
         appMixin.methods.refreshData.call(this)
         this.fetchActiveUsers()
+        this.fetchRequiredSettings(true)
       },
     },
   }

--- a/untangle-vue-ui/source/src/components/Apps/apps/CaptivePortal/CaptivePortal.vue
+++ b/untangle-vue-ui/source/src/components/Apps/apps/CaptivePortal/CaptivePortal.vue
@@ -1,24 +1,116 @@
 <template>
-  <div>
-    <h1>{{ appDisplayName }}</h1>
-  </div>
+  <captive-portal
+    :settings="settings"
+    :app-data="consolidatedAppData"
+    :sessions-data="sessionsData"
+    :metrics-data="formattedMetrics"
+    :reports="appReports"
+    :active-users="activeUsers"
+    @toggle-state="toggleAppState"
+    @logout-user="logoutUser"
+    @refresh-active-users="fetchActiveUsers"
+  >
+    <!-- Custom action buttons slot -->
+    <template #actions="{ newSettings, isDirty }">
+      <div class="d-flex flex-wrap align-center" style="gap: 8px">
+        <div style="min-width: 140px">
+          <u-app-status-remove class="mt-0" :app-name="appDisplayName" @remove="removeApp" />
+        </div>
+        <v-divider vertical class="mx-4" />
+        <u-btn class="mr-2" @click="refreshData">{{ $t('refresh') }}</u-btn>
+        <u-btn :disabled="!isDirty || saveDisabled" @click="saveSettings(newSettings)">{{ $t('save') }}</u-btn>
+      </div>
+    </template>
+  </captive-portal>
 </template>
 
 <script>
+  import { CaptivePortal, UAppStatusRemove } from 'vuntangle'
+  import { VDivider } from 'vuetify/lib'
+  import appMixin from '../appMixin'
+
   export default {
-    name: 'CaptivePortal',
+    name: 'CaptivePortalApp',
+
+    components: { CaptivePortal, UAppStatusRemove, VDivider },
+
+    mixins: [appMixin],
 
     props: {
       appData: { type: Object, default: null },
     },
 
+    data() {
+      return {
+        appName: this.appData?.appName || 'captive-portal',
+        activeUsers: [],
+      }
+    },
+
     computed: {
-      /**
-       * Application display name, derived from appData properties or defaults to a static string
-       * @param param0 - Destructured appData from component's props
-       * @returns {string} Display name for the application
-       */
       appDisplayName: ({ appData }) => appData?.appProperties?.displayName || 'Captive Portal',
+
+      consolidatedAppData: ({ appData, powerState }) => {
+        return {
+          ...appData,
+          powerState: powerState || {},
+        }
+      },
+    },
+
+    watch: {
+      appManager: {
+        async handler(manager) {
+          if (!manager) return
+          await this.fetchActiveUsers()
+        },
+      },
+    },
+
+    methods: {
+      /**
+       * Fetches the list of active users from the app manager and updates the component state.
+       */
+      async fetchActiveUsers() {
+        if (!this.appManager) return
+
+        const users = await new Promise(resolve => {
+          this.appManager.getActiveUsersV2((result, ex) => {
+            if (ex) {
+              resolve([])
+            } else {
+              resolve(result?.list || result || [])
+            }
+          })
+        })
+
+        this.activeUsers = users
+      },
+
+      /**
+       * logout user by userAddress
+       * @param userAddress User Address to logout
+       */
+      async logoutUser(userAddress) {
+        if (!this.appManager || !userAddress) return
+
+        await new Promise(resolve => {
+          this.appManager.userAdminLogout(result => {
+            resolve(result)
+          }, userAddress)
+        })
+
+        await this.fetchActiveUsers()
+      },
+
+      /**
+       * Overrides the refreshData method from appMixin to also refresh the active users list when the main app data is refreshed.
+       * This ensures that the UI reflects the most up-to-date information about active users whenever a refresh is triggered.
+       */
+      refreshData() {
+        appMixin.methods.refreshData.call(this)
+        this.fetchActiveUsers()
+      },
     },
   }
 </script>

--- a/untangle-vue-ui/source/src/components/Apps/apps/CaptivePortal/CaptivePortal.vue
+++ b/untangle-vue-ui/source/src/components/Apps/apps/CaptivePortal/CaptivePortal.vue
@@ -28,6 +28,7 @@
   import { CaptivePortal, UAppStatusRemove } from 'vuntangle'
   import { VDivider } from 'vuetify/lib'
   import appMixin from '../appMixin'
+  import conditionDataMixin from '../conditionDataMixin'
   import util from '@/util/util'
 
   export default {
@@ -35,7 +36,7 @@
 
     components: { CaptivePortal, UAppStatusRemove, VDivider },
 
-    mixins: [appMixin],
+    mixins: [appMixin, conditionDataMixin(['directory-connector'])],
 
     props: {
       appData: { type: Object, default: null },
@@ -45,8 +46,10 @@
       return {
         $remoteData: () => ({
           interfaces: this.interfaces,
+          directoryGroups: this.directoryGroups,
+          directoryDomains: this.directoryDomains,
         }),
-        $features: {},
+        $features: { isExpertMode: this.isExpertMode },
         $readOnly: false,
         $applications: {},
       }
@@ -79,6 +82,13 @@
       interfaces: ({ networkSettings }) => {
         return util.getInterfaceList(networkSettings, true, true)
       },
+
+      /**
+       * Checks if the current user has expert mode enabled
+       * @param param0 vuex store to access the config module and check if expert mode is enabled
+       * @returns {boolean} true if expert mode is enabled, false otherwise
+       */
+      isExpertMode: ({ $store }) => $store.getters['config/isExpertMode'],
     },
 
     // Fetch the required settings when the component is created

--- a/untangle-vue-ui/source/src/components/Apps/apps/conditionDataMixin.js
+++ b/untangle-vue-ui/source/src/components/Apps/apps/conditionDataMixin.js
@@ -1,0 +1,30 @@
+/**
+ * Factory mixin for app components that need runtime condition dropdown data.
+ *
+ * @param {string[]} appNames - Service names whose condition data to fetch (e.g. ['directory-connector'])
+ *
+ * Usage:
+ *   import conditionDataMixin from '../conditionDataMixin'
+ *   mixins: [appMixin, conditionDataMixin(['directory-connector'])]
+ *
+ *   Then include the needed keys in provide() → $remoteData:
+ *   $remoteData: () => ({ ..., directoryGroups: this.directoryGroups, directoryDomains: this.directoryDomains })
+ */
+export default function conditionDataMixin(appNames = []) {
+  return {
+    computed: {
+      conditionData: ({ $store }) => $store.getters['apps/conditionData'],
+      directoryGroups: ({ conditionData }) =>
+        conditionData?.directoryGroups?.length
+          ? [{ text: 'Any Group', value: '*' }, ...conditionData.directoryGroups]
+          : [],
+      directoryDomains: ({ conditionData }) =>
+        conditionData?.directoryDomains?.length
+          ? [{ text: 'Any Domain', value: '*' }, ...conditionData.directoryDomains]
+          : [],
+    },
+    created() {
+      this.$store.dispatch('apps/fetchConditionData', appNames)
+    },
+  }
+}

--- a/untangle-vue-ui/source/src/components/settings/firewall/DenialOfService.vue
+++ b/untangle-vue-ui/source/src/components/settings/firewall/DenialOfService.vue
@@ -45,7 +45,7 @@
       networkSettings: ({ $store }) => $store.getters['config/networkSetting'],
 
       /**
-       * eturns the interfaces for condition value from network settings
+       * returns the interfaces for condition value from network settings
        * @param {Object} vm.networkSettings
        */
       interfaces: ({ networkSettings }) => {

--- a/untangle-vue-ui/source/src/store/apps.js
+++ b/untangle-vue-ui/source/src/store/apps.js
@@ -57,6 +57,31 @@ const APP_BOOTSTRAP_REGISTRY = {
 }
 
 /**
+ * Registry of per-service fetchers for condition runtime data.
+ * Each entry receives the Vuex action context and commits its results via SET_CONDITION_DATA.
+ * Add a new entry here when another service needs to supply condition dropdown values.
+ */
+const CONDITION_DATA_FETCHERS = {
+  'directory-connector': async ({ commit, dispatch }) => {
+    const app = await dispatch('getApp', { appName: 'directory-connector' })
+    if (!app) return
+
+    const [groupResult, domainResult] = await Promise.all([
+      new Promise(resolve => app.getRuleConditionalGroupEntriesV2((r, ex) => resolve(ex ? null : r))),
+      new Promise(resolve => app.getRuleConditionalDomainEntriesV2((r, ex) => resolve(ex ? null : r))),
+    ])
+
+    commit('SET_CONDITION_DATA', {
+      directoryGroups: (groupResult || []).map(g => ({
+        text: `${g.CN} [${g.SAMAccountName}]`,
+        value: g.SAMAccountName,
+      })),
+      directoryDomains: (domainResult || []).map(d => ({ text: d, value: d })),
+    })
+  },
+}
+
+/**
  * Apps store
  */
 const getDefaultState = () => ({
@@ -66,6 +91,7 @@ const getDefaultState = () => ({
   installingApps: {}, // tracks apps currently being installed { appName: { policyId, status } }
   selectedPolicyId: null, // currently selected policy ID
   autoInstallApps: false, // tracks if recommended apps are being auto-installed on initial setup
+  conditionData: {}, // cross-app runtime data for condition dropdowns (groups, domains, etc.)
 })
 
 /**
@@ -115,6 +141,11 @@ const getters = {
    * Usage: getters['apps/autoInstallApps']
    */
   autoInstallApps: state => state.autoInstallApps,
+  /**
+   * Get runtime condition data fetched from external services (directory-connector, etc.)
+   * Usage: getters['apps/conditionData']
+   */
+  conditionData: state => state.conditionData,
   /**
    * Get app data for a specific policy and app combination
    * Returns an object containing: policyId, appName, license, instance, and appProperties
@@ -302,6 +333,13 @@ const mutations = {
    */
   SET_AUTO_INSTALL_APPS(state, value) {
     set(state, 'autoInstallApps', value)
+  },
+  /**
+   * Merge new condition data into the conditionData state slot.
+   * Usage: commit('SET_CONDITION_DATA', { directoryGroups: [...], directoryDomains: [...] })
+   */
+  SET_CONDITION_DATA(state, data) {
+    set(state, 'conditionData', { ...state.conditionData, ...data })
   },
 }
 
@@ -767,6 +805,27 @@ const actions = {
       Util.handleException(error)
       return null
     }
+  },
+
+  /**
+   * Fetch runtime condition data from one or more services and store in conditionData.
+   * Callers pass the service name(s) they need; only the matching registry entries are invoked.
+   * @param {Object} context - Vuex context
+   * @param {string|string[]} appNames - Service name(s) to fetch data from (e.g. 'directory-connector')
+   */
+  async fetchConditionData(context, appNames) {
+    const names = Array.isArray(appNames) ? appNames : [appNames]
+    await Promise.all(
+      names.map(async name => {
+        const fetcher = CONDITION_DATA_FETCHERS[name]
+        if (!fetcher) return
+        try {
+          await fetcher(context)
+        } catch (e) {
+          // Silently degrade — static fallback options remain in the UI
+        }
+      }),
+    )
   },
 }
 

--- a/untangle-vue-ui/source/src/store/apps.js
+++ b/untangle-vue-ui/source/src/store/apps.js
@@ -64,7 +64,11 @@ const APP_BOOTSTRAP_REGISTRY = {
 const CONDITION_DATA_FETCHERS = {
   'directory-connector': async ({ commit, dispatch }) => {
     const app = await dispatch('getApp', { appName: 'directory-connector' })
-    if (!app) return
+    if (!app) {
+      // Clear any stale data left from a previous installation so static fallback options are shown
+      commit('SET_CONDITION_DATA', { directoryGroups: [], directoryDomains: [] })
+      return
+    }
 
     const [groupResult, domainResult] = await Promise.all([
       new Promise(resolve => app.getRuleConditionalGroupEntriesV2((r, ex) => resolve(ex ? null : r))),

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -2617,9 +2617,9 @@ base@^0.11.1:
     pascalcase "^0.1.1"
 
 baseline-browser-mapping@^2.10.12:
-  version "2.10.19"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz#7697721c22f94f66195d0c34299b1a91e3299493"
-  integrity sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==
+  version "2.10.20"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz#7c99b86d43ae9be3810cac515f4675802e1f6b87"
+  integrity sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==
 
 batch-processor@1.0.0:
   version "1.0.0"
@@ -2768,7 +2768,7 @@ call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
     es-errors "^1.3.0"
     function-bind "^1.1.2"
 
-call-bind@^1.0.7, call-bind@^1.0.8:
+call-bind@^1.0.7, call-bind@^1.0.8, call-bind@^1.0.9:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.9.tgz#39a644700c80bc7d0ca9102fc6d1d43b2fd7eee7"
   integrity sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==
@@ -2825,9 +2825,9 @@ caniuse-lite@^1.0.30001726:
   integrity sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==
 
 caniuse-lite@^1.0.30001782:
-  version "1.0.30001788"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz#31e97d1bfec332b3f2d7eea7781460c97629b3bf"
-  integrity sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==
+  version "1.0.30001790"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz#04660c7de15f445d86dd10ac88a8936ac0698e45"
+  integrity sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"
@@ -3591,9 +3591,9 @@ electron-to-chromium@^1.5.173:
   integrity sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==
 
 electron-to-chromium@^1.5.328:
-  version "1.5.336"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.336.tgz#d7c25c0827b8c5e2885b2c91ac6cdcf3e5a1386e"
-  integrity sha512-AbH9q9J455r/nLmdNZes0G0ZKcRX73FicwowalLs6ijwOmCJSRRrLX63lcAlzy9ux3dWK1w1+1nsBJEWN11hcQ==
+  version "1.5.343"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.343.tgz#8e5fb55a61fb1053d888f964f29b65814afed847"
+  integrity sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -4680,10 +4680,17 @@ hash-sum@^2.0.0:
   resolved "https://registry.yarnpkg.com/hash-sum/-/hash-sum-2.0.0.tgz#81d01bb5de8ea4a214ad5d6ead1b523460b0b45a"
   integrity sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==
 
-hasown@^2.0.0, hasown@^2.0.2:
+hasown@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
+hasown@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.3.tgz#5e5c2b15b60370a4c7930c383dfb76bf17bc403c"
+  integrity sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==
   dependencies:
     function-bind "^1.1.2"
 
@@ -5882,9 +5889,9 @@ node-releases@^2.0.19:
   integrity sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==
 
 node-releases@^2.0.36:
-  version "2.0.37"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.37.tgz#9bd4f10b77ba39c2b9402d4e8399c482a797f671"
-  integrity sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==
+  version "2.0.38"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.38.tgz#791569b9e4424a044e12c3abfad418ed83ce9947"
+  integrity sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==
 
 normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -6938,13 +6945,13 @@ run-parallel@^1.1.9:
     queue-microtask "^1.2.2"
 
 safe-array-concat@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.1.3.tgz#c9e54ec4f603b0bbb8e7e5007a5ee7aecd1538c3"
-  integrity sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/safe-array-concat/-/safe-array-concat-1.1.4.tgz#a54cc9b61a57f33b42abad3cbdda3a2b38cc5719"
+  integrity sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==
   dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.2"
-    get-intrinsic "^1.2.6"
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
+    get-intrinsic "^1.3.0"
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
@@ -8160,8 +8167,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.61.37"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#4897903e64932789ac92e527de9ac67e24a511db"
+  version "1.61.46"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#bd7bc4d0884810b1a81b0cec02b326fd4f468807"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
## Related Jira Tickets
- [VueJS App][Captive Portal] Implement: UI for Status Tab
- [VueJS App][Captive Portal] Implement: UI for Capture Rules Tab

---

## Summary

Wires the Captive Portal Vue UI into the ngfw_pkgs app host and introduces a generic
runtime condition data infrastructure — a reusable Vuex action + factory mixin pattern
that fetches live condition dropdown values (AD groups, domains) from backend services
at runtime, with graceful degradation when services are unavailable.

---

## Changes

### `CaptivePortal/CaptivePortal.vue` — App Host Component

Serves as the ngfw_pkgs-layer container for the Captive Portal app. Wraps the
`CaptivePortal` component from `vuntangle` and handles all backend concerns.

**Settings & lifecycle**
- Uses `appMixin` for settings loading, dirty-tracking, save, and app power toggling
- `fetchRequiredSettings()` loads network interface data from the config store on
  `created` and on every manual refresh

**Active Sessions — Status Tab**
- `fetchActiveUsers()` calls `appManager.getActiveUsersV2()` and stores the result in
  `activeUsers`; triggered when `appManager` becomes available and on every refresh
- `logoutUser(userAddress)` calls `appManager.userAdminLogout()` then re-fetches the
  active users list

**Directory Connector integration — runtime condition data**
- Applies `conditionDataMixin(['directory-connector'])`, which on `created` dispatches
  `apps/fetchConditionData` to load live AD groups and domains
- Provides `directoryGroups` and `directoryDomains` (from the mixin, with
  "Any Group" / "Any Domain" prepended) via `$remoteData` so `RuleCondition.vue` in
  vuntangle can populate condition dropdowns without any RPC calls in that library

```js
$remoteData: () => ({
  interfaces:       this.interfaces,        // network interface list
  directoryGroups:  this.directoryGroups,   // live AD groups ([] if DC absent)
  directoryDomains: this.directoryDomains,  // live AD domains ([] if DC absent)
})
```

---

### `Apps/apps/conditionDataMixin.js` — NEW — Generic Runtime Condition Data Mixin

A factory function that returns a reusable Vue mixin. Any app component can consume it
by passing the list of backend services whose condition data it requires:

```js
mixins: [appMixin, conditionDataMixin(['directory-connector'])]
```

**Computed properties exposed**

| Property | Description |
|---|---|
| `conditionData` | Full `apps/conditionData` Vuex getter |
| `directoryGroups` | `[{ text: 'Any Group', value: '*' }, ...live groups]` or `[]` |
| `directoryDomains` | `[{ text: 'Any Domain', value: '*' }, ...live domains]` or `[]` |

**Extensibility**

Adding a new service (e.g. `threat-prevention`) requires only:
1. A new entry in the `CONDITION_DATA_FETCHERS` registry in `apps.js`
2. Adding `'threat-prevention'` to the `conditionDataMixin([...])` call in the
   relevant app component

No changes to callers or the mixin itself are needed.

---

### `store/apps.js` — Condition Data State Extension

Three additions to the existing store module — no new store file created.

**State**

```js
conditionData: {}  // generic slot for cross-app runtime condition dropdown data
```

**Getter**

```js
conditionData: state => state.conditionData
```

**Mutation — `SET_CONDITION_DATA(state, data)`**

Merges incoming data into `conditionData` using object spread, preserving data already
committed by other services.

**Action — `fetchConditionData(context, appNames)`**

Accepts a single service name or an array of names. Dispatches all fetches in parallel
via `Promise.all`. Each fetch is wrapped in a try/catch — a failing service silently
degrades to static fallback options without affecting other services.

**Registry — `CONDITION_DATA_FETCHERS`**

| Service | RPC Calls | Stored Keys |
|---|---|---|
| `directory-connector` | `getRuleConditionalGroupEntriesV2()`, `getRuleConditionalDomainEntriesV2()` | `directoryGroups`, `directoryDomains` |

> The fetcher returns early (no-op) if the `directory-connector` app is not installed.

**Data format committed to store**

```js
{
  directoryGroups:  [{ text: 'CN [SAMAccountName]', value: 'SAMAccountName' }, ...],
  directoryDomains: [{ text: 'corp.local', value: 'corp.local' }, ...],
}
```

---

## Test Plan

- [x] **Status Tab — Active Sessions**: verify `fetchActiveUsers` populates the grid on
      mount; Logout action calls `userAdminLogout` and refreshes the list; Refresh
      button triggers a full data reload including network settings
- [x] **Capture Rules Tab — Save/Cancel**: saving persists changes; dirty state clears
      after save; cancelling discards unsaved changes
- [x] **DC installed**: `conditionDataMixin` dispatches `fetchConditionData` on mount;
      Vuex `conditionData` state contains `directoryGroups` and `directoryDomains`;
      condition dropdown in Capture Rules shows live AD data with "Any Group" /
      "Any Domain" prepended
- [x] **DC not installed**: `getApp({ appName: 'directory-connector' })` returns null;
      fetcher exits early; `conditionData` stays empty; mixin returns `[]`; dropdown
      shows only static fallback options; no console errors
- [x] **Second app reuse**: a second app applying `conditionDataMixin(['directory-connector'])`
      reads from the already-populated Vuex state without triggering a second RPC
      round-trip
