### PR TITLE
NGFW-15796: blacklist NVMe target modules (CVE-2026-23112)

### DIFF
--- a/untangle-linux-config/debian/changelog
+++ b/untangle-linux-config/debian/changelog
@@ -1,3 +1,12 @@
+untangle-linux-config (6.1.1-1) current; urgency=medium
+
+  * CVE-2026-23112: blacklist NVMe target modules (nvmet, nvmet_tcp,
+    nvmet_rdma, nvmet_fc) via /etc/modprobe.d/blacklist-nvmet.conf.
+    NGFW never uses NVMe target functionality; modules ship on disk
+    from Debian defaults but are never loaded at runtime.
+
+ -- Rohit Singh <rohit.singh@arista.com>  Sun, 01 Jun 2026 12:00:00 +0530
+
 untangle-linux-config (6.1.0~svn20090123r21556trunk-1lenny) chaos; urgency=low
 
   * auto build

--- a/untangle-linux-config/files/etc/modprobe.d/blacklist-nvmet.conf
+++ b/untangle-linux-config/files/etc/modprobe.d/blacklist-nvmet.conf
@@ -1,0 +1,9 @@
+blacklist nvmet
+blacklist nvmet_tcp
+blacklist nvmet_rdma
+blacklist nvmet_fc
+
+install nvmet /bin/false
+install nvmet_tcp /bin/false
+install nvmet_rdma /bin/false
+install nvmet_fc /bin/false


### PR DESCRIPTION
Ship /etc/modprobe.d/blacklist-nvmet.conf via untangle-linux-config to prevent loading nvmet, nvmet_tcp, nvmet_rdma, nvmet_fc modules. NGFW never uses NVMe target functionality; modules exist on disk from Debian kernel defaults but are never loaded at runtime.