### PR TITLE
ngfw-15785 updated WebFilter.vue with Status tab code

### DIFF
--- a/untangle-vue-ui/source/src/components/Apps/apps/WebFilter/WebFilter.vue
+++ b/untangle-vue-ui/source/src/components/Apps/apps/WebFilter/WebFilter.vue
@@ -1,24 +1,71 @@
 <template>
-  <div>
-    <h1>{{ appDisplayName }}</h1>
-  </div>
+  <web-filter
+    :settings="settings"
+    :app-data="consolidatedAppData"
+    :tabs="webFilterAllTabs"
+    :sessions-data="sessionsData"
+    :metrics-data="formattedMetrics"
+    :reports="appReports"
+    @toggle-state="toggleAppState"
+  >
+    <template #actions="{ newSettings, isDirty }">
+      <div class="d-flex flex-wrap align-center" style="gap: 8px">
+        <div style="min-width: 140px">
+          <u-app-status-remove class="mt-0" :app-name="appDisplayName" @remove="removeApp" />
+        </div>
+        <v-divider vertical class="mx-4" />
+        <u-btn class="mr-2" @click="refreshData">{{ $t('refresh') }}</u-btn>
+        <u-btn :disabled="!isDirty || saveDisabled" @click="saveSettings(newSettings)">{{ $t('save') }}</u-btn>
+      </div>
+    </template>
+  </web-filter>
 </template>
 
 <script>
+  import { WebFilter, UAppStatusRemove, webFilterDefaultCapabilities, webFilterAllTabs } from 'vuntangle'
+  import { VDivider } from 'vuetify/lib'
+  import appMixin from '../appMixin'
+
   export default {
-    name: 'WebFilter',
+    name: 'WebFilterApp',
+
+    components: { WebFilter, UAppStatusRemove, VDivider },
+
+    mixins: [appMixin],
+
+    provide() {
+      return {
+        capabilities: {
+          ...webFilterDefaultCapabilities,
+          main: {
+            policyManagerAlert: { render: false },
+            enableToggle: { render: false },
+            appIcon: { render: true },
+            powerStatus: { render: true },
+            description: { render: true, key: 'app_web_filter_description' },
+          },
+        },
+        $features: { isExpertMode: this.isExpertMode },
+        $readOnly: false,
+        $applications: {},
+      }
+    },
 
     props: {
       appData: { type: Object, default: null },
     },
 
+    data() {
+      return {
+        appName: this.appData?.appName || 'web-filter',
+        defaultDisplayName: 'Web Filter',
+        webFilterAllTabs,
+      }
+    },
+
     computed: {
-      /**
-       * Application display name, derived from appData properties or defaults to a static string
-       * @param param0 - Destructured appData from component's props
-       * @returns {string} Display name for the application
-       */
-      appDisplayName: ({ appData }) => appData?.appProperties?.displayName || 'Web Filter',
+      consolidatedAppData: appInstance => appInstance.buildConsolidatedAppData(),
+      isExpertMode: ({ $store }) => $store.getters['config/isExpertMode'],
     },
   }
 </script>

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -3624,9 +3624,9 @@ electron-to-chromium@^1.5.173:
   integrity sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==
 
 electron-to-chromium@^1.5.328:
-  version "1.5.366"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.366.tgz#54cfb4090db768d58dce9ef5a2f8b837e61ebe6b"
-  integrity sha512-OlRuhb688YTCzzU3gXPLn6nGyd+F+53INE1qaKKlu6kETErE8FYsyDh0XqXEU+uBRn0MpCzz2vfNwORhkap8qg==
+  version "1.5.368"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz#8e8d4600c5f5f01e891f8f843b4a941afb640412"
+  integrity sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -7121,9 +7121,9 @@ semver@^7.1.2, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.5.4:
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
 semver@^7.3.5:
-  version "7.8.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.1.tgz#bf4970b5e70fda0686363cc18bfe8805d5ed957e"
-  integrity sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==
+  version "7.8.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.2.tgz#194bd65723a28cf82542d2bf176b91c26b343be1"
+  integrity sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==
 
 send@0.19.0:
   version "0.19.0"
@@ -8212,8 +8212,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.61.86"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#c7a1d8a003881e3e20246bbb56210609bbb5904f"
+  version "1.61.91"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#a41642239d4da0ec128496e564456f0357651f5f"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
## Summary

Wires the NGFW WebFilter host component to the new `WebFilter` shared component from vuntangle, enabling the Status tab with live app power toggling, sessions chart, metrics, and reports. This replaces the stub UI with a fully functional NGFW WebFilter app view.

## Motivation

The vuntangle `WebFilter` component now supports a Status tab (power toggle, sessions, metrics, reports) as the first NGFW-specific tab. The NGFW host wrapper needs to supply the required data props and handle the `toggle-state` event emitted by the Status tab's power toggle.

## Changes

### `src/components/Apps/apps/WebFilter/WebFilter.vue`

- **Event handling** — Added `@toggle-state="toggleAppState"` to the `<web-filter>` template binding. Routes the power toggle emitted by `StatusTab` → `UAppStatusState` → `Main.vue` → host, calling `toggleAppState` from `appMixin` to start/stop the app via RPC.
- **Capabilities override** — `provide()` sets NGFW-specific capability flags: hides `policyManagerAlert` and `enableToggle` (moved to Status tab), shows `appIcon` and `powerStatus`, uses `app_web_filter_description` i18n key.
- **Tab configuration** — Passes `webFilterAllTabs` (all 9 tabs) via `:tabs` prop so the Status tab appears as the default first tab in NGFW context.
- **Status tab data** — Passes `:sessions-data="sessionsData"`, `:metrics-data="formattedMetrics"`, `:reports="appReports"` and `:app-data="consolidatedAppData"` — all sourced from `appMixin` computed properties already present in the component.

## Testing

1. Open the Web Filter app in the NGFW admin UI — confirm the **Status** tab loads as the default view.
2. Verify the center panel shows the power toggle with the app's display name and current on/off state.
3. Verify the east panel shows the live sessions chart and metrics table, both updating on poll ticks.
4. Verify the reports section shows available Web Filter reports (requires Reports app installed).
5. Toggle the app off — confirm the app stops, power indicator updates in the header, and chart/metrics show disabled state.
6. Toggle the app on — confirm the app starts and all Status tab widgets reflect the running state.
7. Switch to the Categories, Block Sites, Pass Sites, and Site Lookup tabs — confirm no regressions.
8. Click Refresh — confirm `refreshData` re-fetches settings and metrics.

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
