### PR TITLE
NGFW-15803 report list implmentation

### DIFF
--- a/untangle-vue-ui/source/src/components/reports/Reports.vue
+++ b/untangle-vue-ui/source/src/components/reports/Reports.vue
@@ -43,12 +43,12 @@
         // TODO: navigate to the selected report detail view
       },
 
-      onExportCategory(categoryName) {
-        exportCategoryReports(this.allReports, categoryName)
+      async onExportCategory(categoryName) {
+        await exportCategoryReports(this.allReports, categoryName)
       },
 
-      onExportAll() {
-        exportCategoryReports(this.allReports)
+      async onExportAll() {
+        await exportCategoryReports(this.allReports)
       },
     },
   }

--- a/untangle-vue-ui/source/src/components/reports/Reports.vue
+++ b/untangle-vue-ui/source/src/components/reports/Reports.vue
@@ -1,0 +1,55 @@
+<template>
+  <reports
+    :features="features"
+    :all-reports="allReports"
+    :app-categories="allCategories"
+    @view-report="onViewReport"
+    @export-category="onExportCategory"
+  >
+    <template #actions>
+      <u-btn @click="onExportAll">{{ $t('export') }}</u-btn>
+    </template>
+  </reports>
+</template>
+<script>
+  import { mapActions, mapGetters } from 'vuex'
+  import { Reports } from 'vuntangle'
+  import { exportCategoryReports } from '@/util/reports'
+  export default {
+    components: { Reports },
+    data() {
+      return {
+        features: {
+          maxReportsPerCard: 4,
+          showViewMore: true,
+          maximizableCards: true,
+          exportable: true,
+        },
+      }
+    },
+
+    computed: {
+      ...mapGetters('reports', ['allReports', 'allCategories']),
+    },
+
+    created() {
+      this.loadReports()
+    },
+
+    methods: {
+      ...mapActions('reports', ['loadReports']),
+
+      onViewReport() {
+        // TODO: navigate to the selected report detail view
+      },
+
+      onExportCategory(categoryName) {
+        exportCategoryReports(this.allReports, categoryName)
+      },
+
+      onExportAll() {
+        exportCategoryReports(this.allReports)
+      },
+    },
+  }
+</script>

--- a/untangle-vue-ui/source/src/layouts/AppDrawer.vue
+++ b/untangle-vue-ui/source/src/layouts/AppDrawer.vue
@@ -197,6 +197,7 @@
         return [
           { name: 'dashboard', to: '/', icon: 'mdi-view-dashboard' },
           { name: 'apps', to: `/apps/${this.selectedPolicyId}`, icon: 'mdi-apps' },
+          { name: 'reports', to: '/reports', icon: 'mdi-chart-box-outline' },
         ]
       },
     },

--- a/untangle-vue-ui/source/src/router/index.js
+++ b/untangle-vue-ui/source/src/router/index.js
@@ -7,6 +7,7 @@ import wizard from './wizard'
 import quarantine from './quarantine'
 import userapi from './userapi'
 import appRouter from './apps'
+import reports from './reports'
 import Dashboard from '@/components/Dashboard/Main'
 import store from '@/store'
 import MetricsPollingService from '@/services/MetricsPollingService'
@@ -45,7 +46,7 @@ const baseRoutes = [
   },
 ]
 
-const routes = baseRoutes.concat(auth, setting, wizard, quarantine, userapi, appRouter, {
+const routes = baseRoutes.concat(auth, setting, wizard, quarantine, userapi, appRouter, reports, {
   path: '*',
   name: 'page-not-found',
   component: UPageNotFound,

--- a/untangle-vue-ui/source/src/router/reports.js
+++ b/untangle-vue-ui/source/src/router/reports.js
@@ -1,0 +1,10 @@
+import Reports from '@/components/reports/Reports.vue'
+
+export default [
+  {
+    name: 'reports',
+    path: '/reports',
+    component: Reports,
+    meta: { helpContext: 'reports' },
+  },
+]

--- a/untangle-vue-ui/source/src/store/reports.js
+++ b/untangle-vue-ui/source/src/store/reports.js
@@ -6,6 +6,7 @@
 
 import Rpc from '@/util/Rpc'
 import Util from '@/util/setupUtil'
+import { baseCategories } from '@/util/reports'
 
 const getDefaultState = () => ({
   // Raw reports array from backend
@@ -37,6 +38,13 @@ const getters = {
   // O(1) lookup by category
   getReportsByCategory: state => category => {
     return state.reportsByCategory[category] || []
+  },
+
+  // Merges built-in system categories with installed app categories from the backend,
+  // then sorts the combined list by viewPosition so categories render in the correct order.
+  allCategories: state => {
+    const appCategories = state.categories.map(cat => ({ ...cat, type: 'app' }))
+    return [...baseCategories, ...appCategories].sort((a, b) => a.viewPosition - b.viewPosition)
   },
 
   isReportsInstalled: state => state.isReportsInstalled,

--- a/untangle-vue-ui/source/src/util/reports.js
+++ b/untangle-vue-ui/source/src/util/reports.js
@@ -2,6 +2,8 @@
  * Report utilities - URL encoding, icons, URL generation, category helpers
  */
 
+import util from '@/util/util'
+
 /**
  * System report categories that are always present regardless of which apps are installed.
  */
@@ -77,7 +79,7 @@ export function formatReportsForUI(reports) {
  * @param {Array}  allReports   - full reports array from the store
  * @param {string} categoryName - category to export; if omitted exports all reports
  */
-export function exportCategoryReports(allReports, categoryName) {
+export async function exportCategoryReports(allReports, categoryName) {
   const COMPUTED_FIELDS = ['localizedTitle', 'localizedDescription', 'slug', 'categorySlug', 'url', 'icon', '_id']
 
   const source = categoryName ? allReports.filter(r => r.category === categoryName) : allReports
@@ -88,12 +90,11 @@ export function exportCategoryReports(allReports, categoryName) {
     return rep
   })
 
-  const filename = `AllReports${categoryName ? '_' + categoryName.replace(/ /g, '_') : ''}.json`
-  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  a.click()
-  URL.revokeObjectURL(url)
+  const gridName = `AllReports${categoryName ? '_' + categoryName.replace(/ /g, '_') : ''}`
+
+  await util.downloadFile('/admin/gridSettings', {
+    gridName,
+    gridData: JSON.stringify(data),
+    type: 'export',
+  })
 }

--- a/untangle-vue-ui/source/src/util/reports.js
+++ b/untangle-vue-ui/source/src/util/reports.js
@@ -1,6 +1,20 @@
 /**
- * Report utilities - URL encoding, icons, URL generation
+ * Report utilities - URL encoding, icons, URL generation, category helpers
  */
+
+/**
+ * System report categories that are always present regardless of which apps are installed.
+ */
+export const baseCategories = [
+  { name: 'hosts', type: 'system', displayName: 'Hosts', viewPosition: 1 },
+  { name: 'devices', type: 'system', displayName: 'Devices', viewPosition: 2 },
+  { name: 'users', type: 'system', displayName: 'Users', viewPosition: 3 },
+  { name: 'network', type: 'system', displayName: 'Network', viewPosition: 4 },
+  { name: 'administration', type: 'system', displayName: 'Administration', viewPosition: 5 },
+  { name: 'events', type: 'system', displayName: 'Events', viewPosition: 6 },
+  { name: 'system', type: 'system', displayName: 'System', viewPosition: 7 },
+  { name: 'shield', type: 'system', displayName: 'Shield', viewPosition: 8 },
+]
 
 /**
  * URL encode for report URLs
@@ -36,7 +50,7 @@ export function getReportUrl(category, title) {
 }
 
 /**
- * Transform backend report to UI format for UAppStatusReports component
+ * Transforms a single backend report entry into the UI display format.
  */
 export function formatReportForUI(report) {
   return {
@@ -55,4 +69,31 @@ export function formatReportsForUI(reports) {
     return []
   }
   return reports.map(formatReportForUI)
+}
+
+/**
+ * Exports report definitions for a category (or all reports) as a downloadable JSON file.
+ * Strips UI-computed fields and triggers a client-side Blob download.
+ * @param {Array}  allReports   - full reports array from the store
+ * @param {string} categoryName - category to export; if omitted exports all reports
+ */
+export function exportCategoryReports(allReports, categoryName) {
+  const COMPUTED_FIELDS = ['localizedTitle', 'localizedDescription', 'slug', 'categorySlug', 'url', 'icon', '_id']
+
+  const source = categoryName ? allReports.filter(r => r.category === categoryName) : allReports
+
+  const data = source.map(report => {
+    const rep = { ...report }
+    COMPUTED_FIELDS.forEach(field => delete rep[field])
+    return rep
+  })
+
+  const filename = `AllReports${categoryName ? '_' + categoryName.replace(/ /g, '_') : ''}.json`
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = filename
+  a.click()
+  URL.revokeObjectURL(url)
 }

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -2650,9 +2650,9 @@ base@^0.11.1:
     pascalcase "^0.1.1"
 
 baseline-browser-mapping@^2.10.12:
-  version "2.10.33"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.33.tgz#27c299b096404978831958d429f48390424c4f9b"
-  integrity sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==
+  version "2.10.34"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz#dedb606362446777cfe328d30d4ee15056d06303"
+  integrity sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==
 
 batch-processor@1.0.0:
   version "1.0.0"
@@ -2858,9 +2858,9 @@ caniuse-lite@^1.0.30001726:
   integrity sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==
 
 caniuse-lite@^1.0.30001782:
-  version "1.0.30001793"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz#238887ddf5fcfc8c36d872394d0a78a517312a72"
-  integrity sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==
+  version "1.0.30001797"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz#1332709e1439f01ff92085dd17001e0a45897ec0"
+  integrity sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"
@@ -3702,7 +3702,7 @@ error-stack-parser@^2.0.6:
   dependencies:
     stackframe "^1.3.4"
 
-es-abstract@^1.23.2, es-abstract@^1.23.5, es-abstract@^1.23.9, es-abstract@^1.24.0:
+es-abstract@^1.23.2, es-abstract@^1.23.5, es-abstract@^1.23.9, es-abstract@^1.24.0, es-abstract@^1.24.2:
   version "1.24.2"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.24.2.tgz#2dbd38c180735ee983f77585140a2706a963ed9a"
   integrity sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==
@@ -3777,7 +3777,7 @@ es-module-lexer@^1.2.1:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.7.0.tgz#9159601561880a85f2734560a9099b2c31e5372a"
   integrity sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==
 
-es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1, es-object-atoms@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz#a2d0b373205724dfa525d23b0c3e1b1ca582c99b"
   integrity sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==
@@ -7591,27 +7591,28 @@ string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
     strip-ansi "^6.0.1"
 
 string.prototype.trim@^1.2.10:
-  version "1.2.10"
-  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz#40b2dd5ee94c959b4dcfb1d65ce72e90da480c81"
-  integrity sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==
+  version "1.2.11"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz#e6bd19cda3985d05a42dda31f3ddf4d35d3430e3"
+  integrity sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==
   dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.2"
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
     define-data-property "^1.1.4"
     define-properties "^1.2.1"
-    es-abstract "^1.23.5"
-    es-object-atoms "^1.0.0"
+    es-abstract "^1.24.2"
+    es-object-atoms "^1.1.2"
     has-property-descriptors "^1.0.2"
+    safe-regex-test "^1.1.0"
 
 string.prototype.trimend@^1.0.9:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz#62e2731272cd285041b36596054e9f66569b6942"
-  integrity sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz#be6bcf4f3fe0460bdeccdb2cf4f971b310f8346e"
+  integrity sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==
   dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.2"
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
     define-properties "^1.2.1"
-    es-object-atoms "^1.0.0"
+    es-object-atoms "^1.1.2"
 
 string.prototype.trimstart@^1.0.8:
   version "1.0.8"
@@ -8212,8 +8213,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.61.91"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#a41642239d4da0ec128496e564456f0357651f5f"
+  version "1.61.92"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#4c6f8020c260c77ff25b0901c7dc91a84a13070d"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"
@@ -8469,9 +8470,9 @@ which-collection@^1.0.2:
     is-weakset "^2.0.3"
 
 which-typed-array@^1.1.16, which-typed-array@^1.1.19:
-  version "1.1.21"
-  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.21.tgz#ea7aab68168079646af06b4a36a6f7d7b72e1c0a"
-  integrity sha512-zbRA8cVm6io/d5W8uIe2hblzN76/Wm3v/yiythQvr+dpBWeqhPSWIDNj4zOyHi4zKbMK6DN34Xsr9jPHJERAEw==
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.22.tgz#8f3cc78aefb40b437346dd40a1dbfa5d1da43fe9"
+  integrity sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==
   dependencies:
     available-typed-arrays "^1.0.7"
     call-bind "^1.0.9"


### PR DESCRIPTION
Implemented Reports landing page store, connector component, and export utility.

- `store/reports.js` — added `reports` Vuex module: loads all report entries and app categories from backend on boot, normalises into `allReports`, `allCategories` (base + app categories merged and sorted by `viewPosition`), and `reportsByCategory` lookup map
- `components/reports/Reports.vue` — host connector that passes store data to the vuntangle `Reports` component via `allReports` and `allCategories` props; handles view-report, export-category events; injects Export All Reports button via #actions slot
- `util/reports.js `— added `exportCategoryReports(allReports, categoryName) `— filters reports by category (or exports all), strips UI-computed fields, and triggers a client-side JSON download; added `baseCategories` constant defining the 8 system categories always present regardless of installed apps

<img width="1900" height="1033" alt="image" src="https://github.com/user-attachments/assets/b694fcf3-ccaa-4039-bbfe-d777c9d2b2fd" />
