### PR TITLE
ngfw-15806 Web Filter categories tab impl

### DIFF
--- a/untangle-vue-ui/source/src/components/Apps/apps/WebFilter/WebFilter.vue
+++ b/untangle-vue-ui/source/src/components/Apps/apps/WebFilter/WebFilter.vue
@@ -33,6 +33,7 @@
 
     mixins: [appMixin],
 
+    // Injects WebFilter capability overrides, feature flags, and read-only state to child components.
     provide() {
       return {
         capabilities: {
@@ -43,6 +44,15 @@
             appIcon: { render: true },
             powerStatus: { render: true },
             description: { render: true, key: 'app_web_filter_description' },
+          },
+          categories: {
+            listGroup: {
+              mode: 'direct',
+              actions: [
+                { value: 'blocked', text: 'block', forceEnabledFor: [] },
+                { value: 'flagged', text: 'flag', forceEnabledFor: [] },
+              ],
+            },
           },
         },
         $features: { isExpertMode: this.isExpertMode },
@@ -64,7 +74,9 @@
     },
 
     computed: {
+      // Transforms appData into the format expected by WebFilter and its child components.
       consolidatedAppData: appInstance => appInstance.buildConsolidatedAppData(),
+
       isExpertMode: ({ $store }) => $store.getters['config/isExpertMode'],
     },
   }

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -2650,9 +2650,9 @@ base@^0.11.1:
     pascalcase "^0.1.1"
 
 baseline-browser-mapping@^2.10.12:
-  version "2.10.34"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.34.tgz#dedb606362446777cfe328d30d4ee15056d06303"
-  integrity sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==
+  version "2.10.35"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz#f0f2232e0de2d2f82cc491bcf830b05ed05937c6"
+  integrity sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==
 
 batch-processor@1.0.0:
   version "1.0.0"
@@ -3624,9 +3624,9 @@ electron-to-chromium@^1.5.173:
   integrity sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==
 
 electron-to-chromium@^1.5.328:
-  version "1.5.368"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.368.tgz#8e8d4600c5f5f01e891f8f843b4a941afb640412"
-  integrity sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==
+  version "1.5.371"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz#fa5684f2a514c57368823f9e75553f9a7c5ef0be"
+  integrity sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -7121,9 +7121,9 @@ semver@^7.1.2, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.5.4:
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
 semver@^7.3.5:
-  version "7.8.2"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.2.tgz#194bd65723a28cf82542d2bf176b91c26b343be1"
-  integrity sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.4.tgz#c73eceebae0616934be8dff28a7fd70757c8e696"
+  integrity sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==
 
 send@0.19.0:
   version "0.19.0"
@@ -7277,7 +7277,7 @@ shelljs@^0.8.3:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-side-channel-list@^1.0.0:
+side-channel-list@^1.0.0, side-channel-list@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/side-channel-list/-/side-channel-list-1.0.1.tgz#c2e0b5a14a540aebee3bbc6c3f8666cc9b509127"
   integrity sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==
@@ -7306,7 +7306,7 @@ side-channel-weakmap@^1.0.2:
     object-inspect "^1.13.3"
     side-channel-map "^1.0.1"
 
-side-channel@^1.0.6, side-channel@^1.1.0:
+side-channel@^1.0.6:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.0.tgz#c3fcff9c4da932784873335ec9765fa94ff66bc9"
   integrity sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==
@@ -7314,6 +7314,17 @@ side-channel@^1.0.6, side-channel@^1.1.0:
     es-errors "^1.3.0"
     object-inspect "^1.13.3"
     side-channel-list "^1.0.0"
+    side-channel-map "^1.0.1"
+    side-channel-weakmap "^1.0.2"
+
+side-channel@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.1.1.tgz#ea02c62e05dc4bea67d4442f0fb71ee192f8e0ab"
+  integrity sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==
+  dependencies:
+    es-errors "^1.3.0"
+    object-inspect "^1.13.4"
+    side-channel-list "^1.0.1"
     side-channel-map "^1.0.1"
     side-channel-weakmap "^1.0.2"
 
@@ -8213,8 +8224,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.61.92"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#4c6f8020c260c77ff25b0901c7dc91a84a13070d"
+  version "1.61.94"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#1f6f8c0fc9822c20fbe61be1dcc346e3e163bdec"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
## Summary

NGFW WebFilter host component now provides capability overrides for the Categories tab, enabling direct-mode data flow with blocked/flagged actions instead of the default diff-mode with 4 actions.

## Motivation

The shared `UListGroup` component in vuntangle was extended to support two data modes (diff and direct). The NGFW host needs to opt into direct mode — where categories come from backend settings with state already embedded — and specify its own action set (blocked/flagged) instead of the MFW/ETM defaults (block/reject/flag/log).

## Changes

- **WebFilter host (`WebFilter.vue`)**
  - Added `categories.listGroup` capability override in `provide()` with `mode: 'direct'` and two actions (`blocked`, `flagged`)
  - This tells the shared CategoriesTab to pass items directly (no catalogue + diff), and render only block/flag checkboxes

## Testing

1. Load the NGFW WebFilter app and navigate to the Categories tab
2. Verify only two action columns appear: **block** and **flag** (not reject/log)
3. Toggle individual item, group-level, and all-level checkboxes — confirm changes persist on save
4. Apply text and action filters — verify hidden categories are preserved when saving
5. Verify MFW/ETM WebFilter categories tab is unaffected (still shows 4 actions in diff mode)

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
