### PR TITLE
NGFW-15811 time range implementation

### DIFF
--- a/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
+++ b/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
@@ -42,8 +42,7 @@
     },
 
     methods: {
-      onFetchData({ query, resolve }) {
-        console.log('Fetching report data...', query, resolve)
+      onFetchData({ resolve }) {
         resolve([])
       },
     },

--- a/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
+++ b/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
@@ -1,0 +1,51 @@
+<template>
+  <div class="d-flex flex-column fill-height">
+    <report-details
+      :view-id="selectedUniqueId"
+      :categories="categoriesForNav"
+      :show-report-selector="true"
+      :is-local-ui="false"
+      @fetch-data="onFetchData"
+      @view-report="onViewReport"
+    />
+  </div>
+</template>
+
+<script>
+  import { mapGetters } from 'vuex'
+  import { ReportDetails } from 'vuntangle'
+  import reportsMixin from './reportsMixin'
+  import { urlEncode } from '@/util/reports'
+
+  export default {
+    components: { ReportDetails },
+
+    mixins: [reportsMixin],
+
+    provide() {
+      return {
+        $dateTimeRangeComponent: 'date-time-range-presets',
+        $serverTimezoneOffsetMs: () => this.timeZoneOffset,
+        $serverClockOffsetMs: () => this.serverClockOffsetMs,
+      }
+    },
+
+    computed: {
+      ...mapGetters('reports', ['categoriesForNav']),
+      ...mapGetters('config', ['timeZoneOffset', 'serverClockOffsetMs']),
+
+      selectedUniqueId() {
+        return this.allReports.find(
+          r => urlEncode(r.category) === this.$route.params.cat && urlEncode(r.title) === this.$route.params.rep,
+        )?.uniqueId
+      },
+    },
+
+    methods: {
+      onFetchData({ query, resolve }) {
+        console.log('Fetching report data...', query, resolve)
+        resolve([])
+      },
+    },
+  }
+</script>

--- a/untangle-vue-ui/source/src/components/reports/Reports.vue
+++ b/untangle-vue-ui/source/src/components/reports/Reports.vue
@@ -14,9 +14,14 @@
 <script>
   import { mapActions, mapGetters } from 'vuex'
   import { Reports } from 'vuntangle'
+  import reportsMixin from './reportsMixin'
   import { exportCategoryReports } from '@/util/reports'
+
   export default {
     components: { Reports },
+
+    mixins: [reportsMixin],
+
     data() {
       return {
         features: {
@@ -29,7 +34,7 @@
     },
 
     computed: {
-      ...mapGetters('reports', ['allReports', 'allCategories']),
+      ...mapGetters('reports', ['allCategories']),
     },
 
     created() {
@@ -38,10 +43,6 @@
 
     methods: {
       ...mapActions('reports', ['loadReports']),
-
-      onViewReport() {
-        // TODO: navigate to the selected report detail view
-      },
 
       async onExportCategory(categoryName) {
         await exportCategoryReports(this.allReports, categoryName)

--- a/untangle-vue-ui/source/src/components/reports/reportsMixin.js
+++ b/untangle-vue-ui/source/src/components/reports/reportsMixin.js
@@ -1,0 +1,27 @@
+import { mapGetters } from 'vuex'
+import { urlEncode } from '@/util/reports'
+
+export default {
+  computed: {
+    ...mapGetters('reports', ['allReports']),
+  },
+
+  methods: {
+    /**
+     * Navigates to the report details page for the given uniqueId.
+     * Resolves the report from the store, then builds cat/rep route params.
+     * @param {String} uniqueId - the report's uniqueId from the backend
+     */
+    onViewReport(uniqueId) {
+      const report = this.allReports.find(r => r.uniqueId === uniqueId)
+      if (!report) return
+      this.$router.push({
+        name: 'report-details',
+        params: {
+          cat: urlEncode(report.category),
+          rep: urlEncode(report.title),
+        },
+      })
+    },
+  },
+}

--- a/untangle-vue-ui/source/src/router/reports.js
+++ b/untangle-vue-ui/source/src/router/reports.js
@@ -1,4 +1,5 @@
 import Reports from '@/components/reports/Reports.vue'
+import ReportDetails from '@/components/reports/ReportDetails.vue'
 
 export default [
   {
@@ -6,5 +7,11 @@ export default [
     path: '/reports',
     component: Reports,
     meta: { helpContext: 'reports' },
+  },
+  {
+    name: 'report-details',
+    path: '/reports/:cat/:rep',
+    component: ReportDetails,
+    meta: { helpContext: 'report-details' },
   },
 ]

--- a/untangle-vue-ui/source/src/store/config.js
+++ b/untangle-vue-ui/source/src/store/config.js
@@ -30,6 +30,7 @@ const getDefaultState = () => ({
   rootCertificates: null,
   serverCertificateVerification: null,
   serverCertificates: null,
+  serverClockOffsetMs: 0,
   publicUrl: null,
 })
 
@@ -50,6 +51,7 @@ const getters = {
   deviceTemperatureInfo: state => state.deviceTemperatureInfo || '',
   users: state => state.users || [],
   timeZoneOffset: state => state.timeZoneOffset || 0,
+  serverClockOffsetMs: state => state.serverClockOffsetMs || 0,
   radiusLogsInfo: state => state.radiusLogsInfo || '',
   systemTimeZones: state => state.systemTimeZones || [],
   enabledWanInterfaces: state => state.enabledWanInterfaces || [],
@@ -99,6 +101,7 @@ const mutations = {
   SET_CLASS_FIELDS_DATA: (state, value) => set(state, 'classFieldsData', value),
   SET_USERS: (state, value) => set(state, 'users', value),
   SET_TIME_ZONE_OFF_SET: (state, value) => set(state, 'timeZoneOffset', value),
+  SET_SERVER_CLOCK_OFFSET_MS: (state, value) => set(state, 'serverClockOffsetMs', value),
   SET_DEVICE_TEMP_INFO: (state, value) => set(state, 'deviceTemperatureInfo', value),
   SET_RADIUS_LOGS: (state, value) => set(state, 'radiusLogsInfo', value),
   SET_SYSTEM_TIMEZONES: (state, value) => set(state, 'systemTimeZones', value),
@@ -296,6 +299,17 @@ const actions = {
       return { success: true, message: null, data } //  success
     } catch (err) {
       Util.handleException(err)
+    }
+  },
+
+  /** Compute server-vs-browser wall-clock delta (ms). Stored once at boot; used by DateTimeRangePresets for server-clock-accurate maxDate and preset times. */
+  getServerClockOffsetMs({ commit }) {
+    try {
+      const serverMs = util.getMilliseconds()
+      commit('SET_SERVER_CLOCK_OFFSET_MS', serverMs - Date.now())
+      return { success: true }
+    } catch (err) {
+      commit('SET_SERVER_CLOCK_OFFSET_MS', 0)
     }
   },
 

--- a/untangle-vue-ui/source/src/store/reports.js
+++ b/untangle-vue-ui/source/src/store/reports.js
@@ -6,7 +6,7 @@
 
 import Rpc from '@/util/Rpc'
 import Util from '@/util/setupUtil'
-import { baseCategories } from '@/util/reports'
+import { baseCategories, urlEncode } from '@/util/reports'
 
 const getDefaultState = () => ({
   // Raw reports array from backend
@@ -35,7 +35,7 @@ const getDefaultState = () => ({
 const getters = {
   allReports: state => state.allReports,
 
-  // O(1) lookup by category
+  // O(1) lookup by category name
   getReportsByCategory: state => category => {
     return state.reportsByCategory[category] || []
   },
@@ -45,6 +45,25 @@ const getters = {
   allCategories: state => {
     const appCategories = state.categories.map(cat => ({ ...cat, type: 'app' }))
     return [...baseCategories, ...appCategories].sort((a, b) => a.viewPosition - b.viewPosition)
+  },
+
+  // Normalized categories shape for the ReportsNav dropdown.
+  // Filters out empty categories and projects only the fields the dropdown needs.
+  categoriesForNav: (state, getters) => {
+    return getters.allCategories
+      .filter(cat => (state.reportsByCategory[cat.displayName] || []).length)
+      .map(cat => ({
+        id: urlEncode(cat.displayName),
+        displayName: cat.displayName,
+        reports: (state.reportsByCategory[cat.displayName] || []).map(r => ({
+          id: r.uniqueId,
+          name: r.title,
+          type: r.type,
+          timeStyle: r.timeStyle,
+          pieStyle: r.pieStyle,
+          description: r.description,
+        })),
+      }))
   },
 
   isReportsInstalled: state => state.isReportsInstalled,

--- a/untangle-vue-ui/source/src/store/session.js
+++ b/untangle-vue-ui/source/src/store/session.js
@@ -40,6 +40,11 @@ const actions = {
         dispatch('apps/getAppsViews', true, { root: true }),
         dispatch('apps/loadAppData', { appName: 'policy-manager' }, { root: true }),
         dispatch('reports/loadReports', null, { root: true }),
+        // Required for server-timezone-aware date/time in Reports date picker.
+        // Must run at boot so DateTimeRangePresets receives the correct offset via $serverTimezoneOffsetMs.
+        dispatch('config/getTimeZoneOffSet', null, { root: true }),
+        // Compute server-vs-browser wall-clock delta so maxDate and presets use server time, not browser time.
+        dispatch('config/getServerClockOffsetMs', null, { root: true }),
       ])
 
       commit('SET_ADMIN_CONTEXT_INITIALIZED', true)

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -2650,9 +2650,9 @@ base@^0.11.1:
     pascalcase "^0.1.1"
 
 baseline-browser-mapping@^2.10.12:
-  version "2.10.35"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz#f0f2232e0de2d2f82cc491bcf830b05ed05937c6"
-  integrity sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==
+  version "2.10.37"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz#3e636475b6b293244e2b23e2c71a2ab9d9e6ba7d"
+  integrity sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==
 
 batch-processor@1.0.0:
   version "1.0.0"
@@ -2858,9 +2858,9 @@ caniuse-lite@^1.0.30001726:
   integrity sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==
 
 caniuse-lite@^1.0.30001782:
-  version "1.0.30001797"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz#1332709e1439f01ff92085dd17001e0a45897ec0"
-  integrity sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==
+  version "1.0.30001799"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz#5c909138c27f1a61219d3e092071c1cc7d32dc55"
+  integrity sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"
@@ -3624,9 +3624,9 @@ electron-to-chromium@^1.5.173:
   integrity sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==
 
 electron-to-chromium@^1.5.328:
-  version "1.5.371"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz#fa5684f2a514c57368823f9e75553f9a7c5ef0be"
-  integrity sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==
+  version "1.5.372"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.372.tgz#ae8ac69942a37b231773b8fb01759f73733599e3"
+  integrity sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -4453,16 +4453,19 @@ function-bind@^1.1.2:
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
 function.prototype.name@^1.1.6, function.prototype.name@^1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.8.tgz#e68e1df7b259a5c949eeef95cdbde53edffabb78"
-  integrity sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.2.0.tgz#758f3e84fa542672454bd5e14cb081a5ce07f70c"
+  integrity sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==
   dependencies:
-    call-bind "^1.0.8"
-    call-bound "^1.0.3"
-    define-properties "^1.2.1"
+    call-bind "^1.0.9"
+    call-bound "^1.0.4"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
     functions-have-names "^1.2.3"
-    hasown "^2.0.2"
+    has-property-descriptors "^1.0.2"
+    hasown "^2.0.4"
     is-callable "^1.2.7"
+    is-document.all "^1.0.0"
 
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
@@ -4725,7 +4728,7 @@ hasown@^2.0.0:
   dependencies:
     function-bind "^1.1.2"
 
-hasown@^2.0.2, hasown@^2.0.3:
+hasown@^2.0.2, hasown@^2.0.3, hasown@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
   integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
@@ -5098,6 +5101,13 @@ is-docker@^2.0.0, is-docker@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
   integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+
+is-document.all@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-document.all/-/is-document.all-1.0.0.tgz#163a4bfb362c6ed7b118ce46cdecc4e37dee3195"
+  integrity sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==
+  dependencies:
+    call-bound "^1.0.4"
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -8224,8 +8234,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.61.94"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#1f6f8c0fc9822c20fbe61be1dcc346e3e163bdec"
+  version "1.61.96"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#eb3b1de533cd686e70deef354d52aa0c27109c09"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
Integrates the date/time range preset picker into the Reports host app.

`config.js` — adds `serverClockOffsetMs` state, getter, and action (`util.getMilliseconds()` for server/browser clock delta)
`session.js` — dispatches `getServerClockOffsetMs` during admin context initialization
`ReportDetails.vue` — provides `$serverTimezoneOffsetMs`, `$serverClockOffsetMs`, and `$dateTimeRangeComponent` down to the vuntangle report tree so the presets picker uses server-timezone-aware dates
`reportsMixin.js` — shared mixin for report time range handling
reports.js (store/router) — report store and route updates to support the new range flow
`Reports.vue` — wired up to consume the new mixin and range state
<img width="1908" height="1042" alt="image" src="https://github.com/user-attachments/assets/2927a568-b7b5-4190-a0f1-1f16ee76155b" />
<img width="1908" height="1042" alt="image" src="https://github.com/user-attachments/assets/2f0909ae-a942-4a0d-a2e5-8847c7c6d99f" />
