### PR TITLE
ngfw-15786 handled setting to avoid console error for vlan interface

### DIFF
--- a/untangle-vue-ui/source/src/components/settings/network/InterfaceEdit.vue
+++ b/untangle-vue-ui/source/src/components/settings/network/InterfaceEdit.vue
@@ -1,6 +1,7 @@
 <template>
   <v-container>
     <settings-interface
+      v-if="intfSetting"
       ref="component"
       :settings="intfSetting"
       :is-saving="isSaving"


### PR DESCRIPTION
**Description:**

Fixed console error occurring while editing a VLAN interface and changing its parent interface.

**Issue :**
When a VLAN interface parent was changed (for example, eth0 → eth1), the save operation completed successfully, but a console error was logged afterward.

**Root Cause**
The VLAN device name changes after updating the parent interface:
    Before save:
    device: eth0.100

    After changing parent interface:
    device: eth1.100

The backend and store were updated with the new device name, but the route parameter still contained the old device name (eth0.100). The interface lookup was performed using the old device value, which returned undefined even though the interface data existed in the store.

**Fix:**
Updated the interface lookup handling to avoid relying only on the old device name and handle cases where the VLAN device name changes after parent interface updates.

Result
VLAN parent interface changes save successfully.
No console error is generated after saving.
Interface settings continue to load correctly after the update.