### PR TITLE
Ngfw 15786 fix vlan interface console errors

### DIFF
--- a/untangle-vue-ui/source/src/components/settings/network/InterfaceEdit.vue
+++ b/untangle-vue-ui/source/src/components/settings/network/InterfaceEdit.vue
@@ -1,6 +1,7 @@
 <template>
   <v-container>
     <settings-interface
+      v-if="intfSetting"
       ref="component"
       :settings="intfSetting"
       :is-saving="isSaving"

--- a/untangle-vue-ui/source/src/components/settings/network/InterfaceEdit.vue
+++ b/untangle-vue-ui/source/src/components/settings/network/InterfaceEdit.vue
@@ -1,7 +1,6 @@
 <template>
   <v-container>
     <settings-interface
-      v-if="intfSetting"
       ref="component"
       :settings="intfSetting"
       :is-saving="isSaving"


### PR DESCRIPTION
**Description:**

The vlan fix has is worked for editing the vlan interface.
Reverting the change as its not working with creating new VLAN interface.
