### PR TITLE
NGFW-15819 report type text and graph functionality changes

### DIFF
--- a/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
+++ b/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
@@ -19,7 +19,7 @@
   import Util from '@/util/setupUtil'
   import { urlEncode } from '@/util/reports'
   import { buildReportView } from '@/util/reportViews'
-  import { PROTOCOL_NAME_MAP } from '@/constants'
+  import { protocolNameMap } from '@/constants'
 
   export default {
     components: { ReportDetails },
@@ -114,7 +114,7 @@
               if (entry.type === 'PIE_GRAPH' && entry.pieGroupColumn === 'protocol') {
                 slices = slices.map(s => ({
                   ...s,
-                  name: PROTOCOL_NAME_MAP[parseInt(s.name)] || s.name,
+                  name: protocolNameMap[parseInt(s.name)] || s.name,
                 }))
               }
 

--- a/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
+++ b/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
@@ -2,6 +2,7 @@
   <div class="d-flex flex-column fill-height">
     <report-details
       :view-id="selectedUniqueId"
+      :view-override="selectedReportView"
       :categories="categoriesForNav"
       :show-report-selector="true"
       :is-local-ui="false"
@@ -15,7 +16,10 @@
   import { mapGetters } from 'vuex'
   import { ReportDetails } from 'vuntangle'
   import reportsMixin from './reportsMixin'
+  import Util from '@/util/setupUtil'
   import { urlEncode } from '@/util/reports'
+  import { buildReportView } from '@/util/reportViews'
+  import { PROTOCOL_NAME_MAP } from '@/constants'
 
   export default {
     components: { ReportDetails },
@@ -31,7 +35,7 @@
     },
 
     computed: {
-      ...mapGetters('reports', ['categoriesForNav']),
+      ...mapGetters('reports', ['allReports', 'categoriesForNav']),
       ...mapGetters('config', ['timeZoneOffset', 'serverClockOffsetMs']),
 
       selectedUniqueId() {
@@ -39,11 +43,95 @@
           r => urlEncode(r.category) === this.$route.params.cat && urlEncode(r.title) === this.$route.params.rep,
         )?.uniqueId
       },
+
+      /**
+       * Builds the view config for the currently selected report entry,
+       * selecting the correct display component based on the report type.
+       */
+      selectedReportView() {
+        const entry = this.allReports.find(r => r.uniqueId === this.selectedUniqueId)
+        return buildReportView(entry)
+      },
     },
 
     methods: {
-      onFetchData({ resolve }) {
-        resolve([])
+      /**
+       * Handles data fetch requests for the selected report entry.
+       * Extracts the time range from query conditions, forwards additional filters to the
+       * backend, and resolves with the processed result ready for chart rendering.
+       *
+       * Chart reports (time-series and pie/column):
+       *   - Backend returns pre-built series or slice arrays
+       *   - Slices whose group column is protocol have numbers resolved to display names
+       *
+       * Text reports:
+       *   - Backend returns raw rows; placeholder values are substituted into the template string
+       */
+      async onFetchData({ query, resolve }) {
+        try {
+          const entry = this.allReports.find(r => r.uniqueId === query.key)
+          if (!entry) {
+            resolve(null)
+            return
+          }
+
+          // Extract the time range boundaries from the query conditions
+          const gtCond = query.userConditions.find(c => c.column === 'time_stamp' && c.operator === 'GT')
+          const ltCond = query.userConditions.find(c => c.column === 'time_stamp' && c.operator === 'LT')
+          const startDate = gtCond ? new Date(gtCond.value) : new Date(Date.now() - 86400000)
+          const endDate = ltCond ? new Date(ltCond.value) : null
+
+          // Forward remaining conditions as filters to the backend query
+          const conditions = query.userConditions
+            .filter(c => c.column !== 'time_stamp')
+            .map(c => ({
+              javaClass: 'com.untangle.app.reports.SqlCondition',
+              column: c.column,
+              operator: c.operator,
+              value: c.value,
+            }))
+
+          const payload = await this.$store.dispatch('reports/fetchReportData', {
+            entry,
+            conditions,
+            startDate,
+            endDate,
+            limit: -1,
+          })
+
+          if (payload.data) {
+            // Chart response: pre-built series or slice data
+            const backendData = payload.data
+
+            if (backendData.series) {
+              const arr = backendData.series
+              Object.defineProperty(arr, '__prebuiltType', { value: 'prebuilt_series', enumerable: false })
+              resolve(arr)
+            } else if (backendData.slices) {
+              let slices = backendData.slices
+
+              // Resolve protocol numbers to display names for reports grouped by protocol
+              if (entry.type === 'PIE_GRAPH' && entry.pieGroupColumn === 'protocol') {
+                slices = slices.map(s => ({
+                  ...s,
+                  name: PROTOCOL_NAME_MAP[parseInt(s.name)] || s.name,
+                }))
+              }
+
+              Object.defineProperty(slices, '__prebuiltType', { value: 'prebuilt_slices', enumerable: false })
+              resolve(slices)
+            } else {
+              resolve(null)
+            }
+          } else if (entry.type === 'TEXT') {
+            resolve(payload.text)
+          } else {
+            resolve(null)
+          }
+        } catch (err) {
+          Util.handleException(err)
+          resolve(null)
+        }
       },
     },
   }

--- a/untangle-vue-ui/source/src/constants/index.js
+++ b/untangle-vue-ui/source/src/constants/index.js
@@ -44,6 +44,59 @@ const appDescription = {
   'ad-blocker': 'app_ad_blocker_description',
 }
 
+/**
+ * IANA protocol number → display name map.
+ * Format mirrors ExtJS Renderer.protocolsMap: "TCP [6]"
+ * Used to resolve raw protocol numbers returned by PIE_GRAPH reports
+ * where pieGroupColumn === 'protocol'. Resolution stays client-side because
+ * this is static data already available in the browser — no backend round-trip needed.
+ */
+const PROTOCOL_NAME_MAP = {
+  0: 'HOPOPT [0]',
+  1: 'ICMP [1]',
+  2: 'IGMP [2]',
+  3: 'GGP [3]',
+  4: 'IPv4 [4]',
+  5: 'ST [5]',
+  6: 'TCP [6]',
+  7: 'CBT [7]',
+  8: 'EGP [8]',
+  9: 'IGP [9]',
+  10: 'BBN-RCC-MON [10]',
+  11: 'NVP-II [11]',
+  12: 'PUP [12]',
+  17: 'UDP [17]',
+  27: 'RDP [27]',
+  33: 'DCCP [33]',
+  41: 'IPv6 [41]',
+  43: 'IPv6-Route [43]',
+  44: 'IPv6-Frag [44]',
+  46: 'RSVP [46]',
+  47: 'GRE [47]',
+  50: 'ESP [50]',
+  51: 'AH [51]',
+  58: 'IPv6-ICMP [58]',
+  59: 'IPv6-NoNxt [59]',
+  60: 'IPv6-Opts [60]',
+  88: 'EIGRP [88]',
+  89: 'OSPFIGP [89]',
+  94: 'IPIP [94]',
+  103: 'PIM [103]',
+  108: 'IPComp [108]',
+  112: 'VRRP [112]',
+  115: 'L2TP [115]',
+  132: 'SCTP [132]',
+  133: 'FC [133]',
+  135: 'Mobility Header [135]',
+  136: 'UDPLite [136]',
+  137: 'MPLS-in-IP [137]',
+  139: 'HIP [139]',
+  140: 'Shim6 [140]',
+  253: 'Use for experimentation [253]',
+  254: 'Use for experimentation [254]',
+  255: 'Reserved [255]',
+}
+
 export {
   booleanValueOptions,
   invertOptions,
@@ -51,4 +104,5 @@ export {
   textOperatorOptions,
   booleanOperatorOptions,
   appDescription,
+  PROTOCOL_NAME_MAP,
 }

--- a/untangle-vue-ui/source/src/constants/index.js
+++ b/untangle-vue-ui/source/src/constants/index.js
@@ -51,7 +51,7 @@ const appDescription = {
  * where pieGroupColumn === 'protocol'. Resolution stays client-side because
  * this is static data already available in the browser — no backend round-trip needed.
  */
-const PROTOCOL_NAME_MAP = {
+const protocolNameMap = {
   0: 'HOPOPT [0]',
   1: 'ICMP [1]',
   2: 'IGMP [2]',
@@ -104,5 +104,5 @@ export {
   textOperatorOptions,
   booleanOperatorOptions,
   appDescription,
-  PROTOCOL_NAME_MAP,
+  protocolNameMap,
 }

--- a/untangle-vue-ui/source/src/store/reports.js
+++ b/untangle-vue-ui/source/src/store/reports.js
@@ -28,6 +28,9 @@ const getDefaultState = () => ({
   // Whether Reports app is installed
   isReportsInstalled: false,
 
+  // Cached reports manager instance — acquired once at boot, reused on every data fetch
+  reportsManager: null,
+
   // Timestamp of last load (for cache invalidation if needed)
   lastLoaded: null,
 })
@@ -104,6 +107,10 @@ const mutations = {
     state.isReportsInstalled = installed
   },
 
+  SET_REPORTS_MANAGER(state, manager) {
+    state.reportsManager = manager
+  },
+
   SET_LAST_LOADED(state, timestamp) {
     state.lastLoaded = timestamp
   },
@@ -135,6 +142,7 @@ const actions = {
       commit('SET_REPORTS_INSTALLED', true)
 
       const reportsManager = await Rpc.asyncData(reportsApp, 'getReportsManager')
+      commit('SET_REPORTS_MANAGER', reportsManager)
 
       // Parallel RPC calls
       const [reportsResult, categoriesResult] = await Promise.all([
@@ -168,6 +176,49 @@ const actions = {
 
   resetReports({ commit }) {
     commit('RESET')
+  },
+
+  /**
+   * Fetches report data from the backend for a given report entry and time range.
+   *
+   * The backend returns a type-aware JSONObject:
+   *   { series: [...] }  for TIME_GRAPH / TIME_GRAPH_DYNAMIC
+   *   { slices: [...] }  for PIE_GRAPH
+   *   { list:   [...] }  for EVENT_LIST / TEXT
+   *
+   * @param {Object} payload
+   * @param {Object} payload.entry       - full ReportEntry object
+   * @param {Array}  payload.conditions  - SQL filter conditions excluding time range entries
+   * @param {Date}   payload.startDate   - query start date
+   * @param {Date}   payload.endDate     - query end date; null means open-ended
+   * @param {Number} payload.limit       - maximum rows to return; -1 for unlimited
+   * @returns {Object} backend payload with either a `data` key (chart) or `list` key (events)
+   */
+  async fetchReportData({ state }, { entry, conditions = [], startDate, endDate, limit = -1 }) {
+    const result = await Rpc.asyncData(
+      state.reportsManager,
+      'getDataForReportEntryV2',
+      entry,
+      startDate,
+      endDate,
+      null,
+      conditions,
+      null,
+      limit,
+    )
+    if (!result) return { list: [] }
+
+    // Chart types return { series: [...] } or { slices: [...] } at the root level
+    if (result.series || result.slices) {
+      return { data: result }
+    }
+
+    // TEXT returns a pre-substituted string from the backend
+    if (result.text !== undefined) {
+      return { text: result.text }
+    }
+
+    return { list: result.list ?? [] }
   },
 }
 

--- a/untangle-vue-ui/source/src/util/reportViews.js
+++ b/untangle-vue-ui/source/src/util/reportViews.js
@@ -1,0 +1,137 @@
+/**
+ * Report view translation layer.
+ * Converts backend report entries into view configs consumed by the display components.
+ */
+
+/**
+ * Maps a time-based chart style to the corresponding chart type.
+ * Bar variants map to 'column'; area variants to 'areaspline'; line to 'spline'.
+ */
+function timeStyleToChartType(timeStyle) {
+  if (!timeStyle) return 'column'
+  if (timeStyle === 'LINE') return 'spline'
+  if (timeStyle.startsWith('AREA')) return 'areaspline'
+  return 'column' // BAR, BAR_OVERLAPPED, BAR_STACKED, BAR_3D*
+}
+
+/**
+ * Maps a pie/distribution chart style to the corresponding chart type.
+ */
+function pieStyleToChartType(pieStyle) {
+  if (!pieStyle) return 'pie'
+  if (pieStyle === 'COLUMN' || pieStyle === 'COLUMN_3D') return 'column'
+  return 'pie' // PIE, PIE_3D, DONUT, DONUT_3D
+}
+
+/**
+ * Builds the report config for a text-type report.
+ * Sets the key from the unique identifier so data fetch events can match the entry.
+ *
+ * @param {Object} entry - report entry definition
+ * @returns {Object} report config for the text display component
+ */
+function translateTextEntry(entry) {
+  return {
+    ...entry,
+    key: entry.uniqueId,
+    query: {}, // no pagination — TEXT reports are not paginated
+  }
+}
+
+/**
+ * Builds the rendering config for a time-series chart report.
+ * Maps time style variants to chart type, stacking, and data grouping options.
+ */
+function translateTimeGraphEntry(entry) {
+  const timeStyle = entry.timeStyle || ''
+  return {
+    key: entry.uniqueId,
+    title: entry.title,
+    query: {},
+    rendering: {
+      type: timeStyleToChartType(timeStyle),
+      units: entry.units,
+      stacking: timeStyle.includes('STACKED') ? 'normal' : undefined,
+      overlapped: timeStyle.includes('OVERLAPPED'),
+      dataGroupingApproximation: entry.approximation || 'sum',
+      groupPixelWidth: 8,
+      colors: Array.isArray(entry.colors) ? entry.colors.join(',') : entry.colors,
+    },
+  }
+}
+
+/**
+ * Builds the rendering config for a dynamic time-series chart report.
+ * Extends the base time-series config with a grouping column for dynamic series discovery.
+ */
+function translateTimeGraphDynamicEntry(entry) {
+  const base = translateTimeGraphEntry(entry)
+  return {
+    ...base,
+    query: {
+      queryCategories: {
+        groupColumn: entry.timeDataDynamicColumn,
+      },
+    },
+  }
+}
+
+/**
+ * Builds the rendering config for a pie or column-distribution chart report.
+ * Maps pie style variants to chart type and donut/slice display options.
+ */
+function translatePieGraphEntry(entry) {
+  const pieStyle = entry.pieStyle || ''
+  return {
+    key: entry.uniqueId,
+    title: entry.title,
+    query: {},
+    rendering: {
+      type: pieStyleToChartType(pieStyle),
+      units: entry.units,
+      donutInnerSize: pieStyle.includes('DONUT') ? 40 : 0,
+      slicesNumber: entry.pieNumSlices || 10,
+      column: entry.pieGroupColumn, // category column used for web category label resolution
+      colors: Array.isArray(entry.colors) ? entry.colors.join(',') : entry.colors,
+    },
+  }
+}
+
+/**
+ * Builds the view config object for a given report entry based on its type.
+ * Selects the correct display component and rendering options at runtime.
+ * verticalLayout expands the chart to fill available height instead of a fixed minimum.
+ *
+ * @param {Object} entry - report entry definition
+ * @returns {Object|null} view config, or null if the type is not yet supported
+ */
+export function buildReportView(entry) {
+  if (!entry) return null
+  switch (entry.type) {
+    case 'TIME_GRAPH':
+      return {
+        component: 'GenericChart',
+        verticalLayout: true,
+        reports: [translateTimeGraphEntry(entry)],
+      }
+    case 'TIME_GRAPH_DYNAMIC':
+      return {
+        component: 'GenericChart',
+        verticalLayout: true,
+        reports: [translateTimeGraphDynamicEntry(entry)],
+      }
+    case 'PIE_GRAPH':
+      return {
+        component: 'GenericChart',
+        verticalLayout: true,
+        reports: [translatePieGraphEntry(entry)],
+      }
+    case 'TEXT':
+      return {
+        component: 'GenericText',
+        reports: [translateTextEntry(entry)],
+      }
+    default:
+      return null
+  }
+}

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -2650,9 +2650,9 @@ base@^0.11.1:
     pascalcase "^0.1.1"
 
 baseline-browser-mapping@^2.10.12:
-  version "2.10.37"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.37.tgz#3e636475b6b293244e2b23e2c71a2ab9d9e6ba7d"
-  integrity sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==
+  version "2.10.38"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz#c84d093c4bf7325c5053c279d90f153c66526042"
+  integrity sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==
 
 batch-processor@1.0.0:
   version "1.0.0"
@@ -3624,9 +3624,9 @@ electron-to-chromium@^1.5.173:
   integrity sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==
 
 electron-to-chromium@^1.5.328:
-  version "1.5.375"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.375.tgz#54a9a616dc2b3765e7263d98d14c2135408954d9"
-  integrity sha512-ZWP5eB4BVPW/ZYo9252hQZHZ5XavtsTgpbhcmMmRwymavC5AsLWQWBPaKMeNd2LW0KGby5HPXvj7+sr4ta5j/Q==
+  version "1.5.376"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz#16a9d4b72cb16c416aa73a879d92b047b96797ac"
+  integrity sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -5956,9 +5956,9 @@ node-releases@^2.0.19:
   integrity sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==
 
 node-releases@^2.0.36:
-  version "2.0.47"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.47.tgz#521bb2786da8eb140b748841c0b3b3a75334ffc4"
-  integrity sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==
+  version "2.0.48"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.48.tgz#4da73d040ada751fc9959d993f27de48792e3b7d"
+  integrity sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==
 
 normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -7143,9 +7143,9 @@ semver@^7.1.2, semver@^7.2.1, semver@^7.3.2, semver@^7.3.4, semver@^7.5.4:
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
 
 semver@^7.3.5:
-  version "7.8.4"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.4.tgz#c73eceebae0616934be8dff28a7fd70757c8e696"
-  integrity sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 send@0.19.0:
   version "0.19.0"
@@ -8246,8 +8246,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.61.99"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#cc517fa4aa0a5bbfd9c51a9e99710da0b585fd17"
+  version "1.62.0"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#5bf307070042555572047d87bd23c052b514d6e5"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
`reportViews.js (new) `— translation layer converting NGFW report entries to vuntangle view configs for each chart and text type
store/reports.js — caches `reportsManager` at boot; each data fetch now makes one RPC call instead of three; detects `result.text` for `TEXT` reports
`ReportDetails.vue `— host adapter bridging vuntangle's `fetch-data` event to the NGFW backend: extracts time range, maps conditions to `SqlCondition[]`, marks arrays for prebuilt rendering, resolves protocol display names