### PR TITLE
NGFW-15829 Event List functionality changes

### DIFF
--- a/untangle-vue-ui/source/package.json
+++ b/untangle-vue-ui/source/package.json
@@ -19,6 +19,7 @@
     "highcharts": "^9.1.2",
     "lodash": "^4.17.21",
     "nanomatch": "^1.2.13",
+    "v-code-diff": "^1.13.1",
     "vee-validate": "^3.4.10",
     "vue": "2.7.16",
     "vue-grid-layout": "^2.3.12",

--- a/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
+++ b/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
@@ -8,7 +8,11 @@
       :is-local-ui="false"
       @fetch-data="onFetchData"
       @view-report="onViewReport"
+      @export-all-events="onExportAllEvents"
     />
+
+    <!-- Settings diff dialog — opened by the  action column on settings_changes rows -->
+    <settings-diff-dialog v-model="diffDialogOpen" :file-name="diffFileName" />
   </div>
 </template>
 
@@ -16,13 +20,15 @@
   import { mapGetters } from 'vuex'
   import { ReportDetails } from 'vuntangle'
   import reportsMixin from './reportsMixin'
+  import SettingsDiffDialog from './SettingsDiffDialog.vue'
   import Util from '@/util/setupUtil'
-  import { urlEncode } from '@/util/reports'
+  import util from '@/util/util'
+  import { urlEncode, clientToServerDate } from '@/util/reports'
   import { buildReportView } from '@/util/reportViews'
   import { protocolNameMap } from '@/constants'
 
   export default {
-    components: { ReportDetails },
+    components: { ReportDetails, SettingsDiffDialog },
 
     mixins: [reportsMixin],
 
@@ -34,9 +40,23 @@
       }
     },
 
+    data() {
+      return {
+        // Diff dialog state — controlled by the  row action on settings_changes reports
+        diffDialogOpen: false,
+        diffFileName: '',
+
+        // Last-used time range — stored each fetch so export uses the same window
+        lastStartMs: null,
+        lastEndMs: null,
+        // Last-used extra conditions (non-time) — forwarded to server export
+        lastConditions: [],
+      }
+    },
+
     computed: {
-      ...mapGetters('reports', ['allReports', 'categoriesForNav']),
-      ...mapGetters('config', ['timeZoneOffset', 'serverClockOffsetMs']),
+      ...mapGetters('reports', ['allReports', 'categoriesForNav', 'policyNameMap']),
+      ...mapGetters('config', ['timeZoneOffset', 'serverClockOffsetMs', 'interfaceNameMap']),
 
       selectedUniqueId() {
         return this.allReports.find(
@@ -45,27 +65,36 @@
       },
 
       /**
-       * Builds the view config for the currently selected report entry,
-       * selecting the correct display component based on the report type.
+       * Builds the view config for the currently selected report entry.
+       * For EVENT_LIST, passes interfaceNameMap and policyNameMap so column cells
+       * and the details panel show resolved names instead of raw IDs.
+       * For settings_changes EVENT_LIST, passes onShowDiff callback so the
+       * action column opens the diff dialog when clicked.
        */
       selectedReportView() {
         const entry = this.allReports.find(r => r.uniqueId === this.selectedUniqueId)
-        return buildReportView(entry)
+        return buildReportView(entry, this.timeZoneOffset, this.interfaceNameMap, this.policyNameMap, {
+          onShowDiff: fileName => {
+            this.diffFileName = fileName
+            this.diffDialogOpen = true
+          },
+        })
       },
+    },
+
+    /**
+     * Fetch policy info once when the component mounts.
+     * The action is a no-op if already loaded or if policy-manager is not installed.
+     */
+    async created() {
+      await this.$store.dispatch('reports/fetchPoliciesInfo')
     },
 
     methods: {
       /**
-       * Handles data fetch requests for the selected report entry.
-       * Extracts the time range from query conditions, forwards additional filters to the
-       * backend, and resolves with the processed result ready for chart rendering.
-       *
-       * Chart reports (time-series and pie/column):
-       *   - Backend returns pre-built series or slice arrays
-       *   - Slices whose group column is protocol have numbers resolved to display names
-       *
-       * Text reports:
-       *   - Backend returns raw rows; placeholder values are substituted into the template string
+       * Handles data fetch requests from the report display component.
+       * Converts the raw epoch ms from the time picker to server-local dates before
+       * dispatching to the store, so PostgreSQL receives the correct local time to filter on.
        */
       async onFetchData({ query, resolve }) {
         try {
@@ -75,13 +104,13 @@
             return
           }
 
-          // Extract the time range boundaries from the query conditions
+          // Extract time range boundaries from conditions and convert to server timezone.
           const gtCond = query.userConditions.find(c => c.column === 'time_stamp' && c.operator === 'GT')
           const ltCond = query.userConditions.find(c => c.column === 'time_stamp' && c.operator === 'LT')
-          const startDate = gtCond ? new Date(gtCond.value) : new Date(Date.now() - 86400000)
-          const endDate = ltCond ? new Date(ltCond.value) : null
+          const startDate = clientToServerDate(gtCond?.value ?? Date.now() - 86400000, this.timeZoneOffset)
+          const endDate = ltCond ? clientToServerDate(ltCond.value, this.timeZoneOffset) : null
 
-          // Forward remaining conditions as filters to the backend query
+          // Forward remaining conditions as SQL filter objects to the backend
           const conditions = query.userConditions
             .filter(c => c.column !== 'time_stamp')
             .map(c => ({
@@ -91,12 +120,21 @@
               value: c.value,
             }))
 
+          // Store for use by the export handler
+          this.lastStartMs = gtCond?.value ?? Date.now() - 86400000
+          this.lastEndMs = ltCond?.value ?? null
+          this.lastConditions = conditions
+
+          // EVENT_LIST carries a user-selected limit from GenericEventList's limit selector.
+          // All other report types use -1 (unlimited — backend applies its own aggregation).
+          const limit = entry.type === 'EVENT_LIST' ? query.limit ?? 1000 : -1
+
           const payload = await this.$store.dispatch('reports/fetchReportData', {
             entry,
             conditions,
             startDate,
             endDate,
-            limit: -1,
+            limit,
           })
 
           if (payload.data) {
@@ -125,12 +163,58 @@
             }
           } else if (entry.type === 'TEXT') {
             resolve(payload.text)
+          } else if (entry.type === 'EVENT_LIST') {
+            resolve(payload.list)
           } else {
             resolve(null)
           }
         } catch (err) {
           Util.handleException(err)
           resolve(null)
+        }
+      },
+
+      /**
+       * Exports all event rows for the current report as a CSV download.
+       * Applies timezone conversion to the stored time range, then POSTs to /admin/download
+       * with the entry definition, conditions, visible columns, and time boundaries.
+       *
+       * @param {string[]} visibleColumns - field names of columns currently visible in the grid
+       */
+      async onExportAllEvents({ visibleColumns }) {
+        const entry = this.allReports.find(r => r.uniqueId === this.selectedUniqueId)
+        if (!entry) return
+
+        // Convert stored epoch ms boundaries to server-local dates for the download request
+        const startDate = clientToServerDate(this.lastStartMs, this.timeZoneOffset)
+        const endDate = this.lastEndMs ? clientToServerDate(this.lastEndMs, this.timeZoneOffset) : null
+
+        // Build filename: "Category-Title-DD.MM.YYYY-HH:mm-DD.MM.YYYY-HH:mm"
+        const fmt = d => {
+          if (!d) return ''
+          const p = n => String(n).padStart(2, '0')
+          return `${p(d.getDate())}.${p(d.getMonth() + 1)}.${d.getFullYear()}-${p(d.getHours())}:${p(d.getMinutes())}`
+        }
+        const filename = `${entry.category}-${entry.title}-${fmt(startDate)}-${fmt(endDate || new Date())}`.replace(
+          / /g,
+          '_',
+        )
+
+        try {
+          // util.downloadFile uses axios POST to the ABSOLUTE /admin/download URL, handles the
+          // Blob response and triggers browser download — avoids the relative-URL problem where
+          // form.action="download" resolved to /console/reports/.../download instead of /admin/download.
+          await util.downloadFile('/admin/download', {
+            type: 'eventLogExport',
+            arg1: filename,
+            arg2: JSON.stringify(entry),
+            arg3: JSON.stringify(this.lastConditions),
+            arg4: (visibleColumns || []).join(','),
+            arg5: startDate ? String(startDate.getTime()) : '-1',
+            arg6: endDate ? String(endDate.getTime()) : '-1',
+          })
+        } catch (err) {
+          Util.handleException(err)
         }
       },
     },

--- a/untangle-vue-ui/source/src/components/reports/SettingsDiffDialog.vue
+++ b/untangle-vue-ui/source/src/components/reports/SettingsDiffDialog.vue
@@ -18,62 +18,29 @@
       </v-alert>
     </div>
 
-    <template v-else>
-      <!-- Color legend -->
-      <div class="d-flex align-center caption grey--text text--darken-1 mb-2" style="gap: 16px">
-        <span class="d-flex align-center">
-          <span class="diff-legend-swatch" style="background: #d9f5cb" />
-          {{ $t('added') }}
-        </span>
-        <span class="d-flex align-center">
-          <span class="diff-legend-swatch" style="background: #ffdfd9" />
-          {{ $t('removed') }}
-        </span>
-        <span class="d-flex align-center">
-          <span class="diff-legend-swatch" style="background: #ffff99" />
-          {{ $t('changed') }}
-        </span>
-      </div>
-
-      <!-- Diff grid — Line | Previous | Current columns.
-           d-flex flex-column is required so UGrid's inner flex-grow-1 has a flex context
-           and AG-Grid receives non-zero height from its parent. -->
-      <div class="d-flex flex-column" style="height: 60vh">
-        <u-grid
-          id="settings-diff-grid"
-          :column-defs="columnDefs"
-          :row-data="diffRows"
-          toolbar="hidden"
-          :custom-grid-options="gridOptions"
-          :custom-default-col-options="defaultColOptions"
-        />
-      </div>
-    </template>
+    <div v-else style="height: 60vh" class="d-flex">
+      <code-diff
+        language="json"
+        :old-string="prevString"
+        :new-string="currString"
+        output-format="side-by-side"
+        class="ma-0"
+      />
+    </div>
   </u-dialog>
 </template>
 
 <script>
-  import { UDialog, UGrid } from 'vuntangle'
+  import { UDialog } from 'vuntangle'
   import { VAlert, VOverlay, VProgressCircular } from 'vuetify/lib'
+  import { CodeDiff } from 'v-code-diff'
   import Rpc from '@/util/Rpc'
   import Util from '@/util/setupUtil'
-
-  // Diff action codes
-  const ACTION_ADDED = 1 // '>' line only in current  → green
-  const ACTION_REMOVED = 2 // '<' line only in previous → red
-  const ACTION_CHANGED = 3 // '|' line differs          → yellow
-
-  // Row background colors
-  const ROW_COLORS = {
-    [ACTION_ADDED]: '#d9f5cb',
-    [ACTION_REMOVED]: '#ffdfd9',
-    [ACTION_CHANGED]: '#ffff99',
-  }
 
   export default {
     name: 'SettingsDiffDialog',
 
-    components: { UDialog, UGrid, VAlert, VOverlay, VProgressCircular },
+    components: { UDialog, VAlert, VOverlay, VProgressCircular, CodeDiff },
 
     props: {
       // v-model — controls dialog open/close
@@ -86,7 +53,8 @@
       return {
         loading: false,
         errorMessage: '',
-        diffRows: [],
+        prevString: '',
+        currString: '',
       }
     },
 
@@ -100,54 +68,6 @@
       dialogTitle() {
         const stripped = this.fileName.replace(/^.*\/settings\//, '').replace(/^.*\/conf\//, '')
         return stripped ? `${this.$t('settings_difference')} — ${stripped}` : this.$t('settings_difference')
-      },
-
-      columnDefs() {
-        return [
-          {
-            field: 'line',
-            headerName: this.$t('line'),
-            width: 70,
-            flex: 0,
-            sortable: false,
-            filter: false,
-            suppressMenu: true,
-          },
-          {
-            field: 'previous',
-            headerName: this.$t('previous'),
-            flex: 1,
-            sortable: false,
-            filter: false,
-            suppressMenu: true,
-          },
-          {
-            field: 'current',
-            headerName: this.$t('current'),
-            flex: 1,
-            sortable: false,
-            filter: false,
-            suppressMenu: true,
-          },
-        ]
-      },
-
-      // Row color by action code
-      gridOptions() {
-        return {
-          getRowStyle: ({ data }) => {
-            const color = ROW_COLORS[data?.action]
-            return color ? { background: color } : null
-          },
-        }
-      },
-
-      // Monospace font + white-space: pre for diff content.
-      // AG-Grid renders text not HTML, so white-space: pre preserves indentation.
-      defaultColOptions() {
-        return {
-          cellStyle: { fontFamily: 'monospace', fontSize: '12px', whiteSpace: 'pre' },
-        }
       },
     },
 
@@ -164,7 +84,8 @@
 
     methods: {
       reset() {
-        this.diffRows = []
+        this.prevString = ''
+        this.currString = ''
         this.errorMessage = ''
         this.loading = false
       },
@@ -173,9 +94,10 @@
         this.reset()
         this.loading = true
         try {
-          // Full dot-path: rpc.settingsManager → getDiff method
           const result = await Rpc.asyncData('rpc.settingsManager.getDiff', this.fileName)
-          this.diffRows = this.parseDiff(result || '')
+          const { prevString, currString } = this.buildFileStrings(result || '')
+          this.prevString = prevString
+          this.currString = currString
         } catch (err) {
           const msg = err?.message || ''
           if (msg.includes('Could not find an earlier file')) {
@@ -192,66 +114,43 @@
       },
 
       /**
-       * Parses the raw output of: diff -y -W1024 -t <previous> <current>
+       * Reconstructs both file content strings from the raw output of:
+       *   diff -y -W1024 -t <previous> <current>
        *
-       * Side-by-side format with -W1024:
-       *   char 0:      part of previous content (unless '<' or '>')
-       *   chars 1–510: rest of previous content (510 chars)
-       *   char 511:    separator: ' '=unchanged | '|'=changed | '<'=removed | '>'=added
-       *   chars 512+:  current content
+       * Each line: chars 0–510 = previous content, char 511 = separator, chars 512+ = current content
+       * Separator: ' '=unchanged  '|'=changed  '<'=removed  '>'=added
        */
-      parseDiff(raw) {
-        const rows = []
-        const lines = raw.split('\n')
+      buildFileStrings(raw) {
+        const prevLines = []
+        const currLines = []
 
-        for (let i = 0; i < lines.length; i++) {
-          const line = lines[i]
+        for (const line of raw.split('\n')) {
           if (!line) continue
 
           const prevMarker = line.substring(0, 1)
           let prev = line.substring(1, 511)
           const sep = line.substring(511, 512)
-          let curr = line.substring(512)
+          const curr = line.substring(512)
 
-          // If char 0 is not a diff side-marker, it is part of previous content
           if (prevMarker !== '<' && prevMarker !== '>') {
             prev = prevMarker + prev
           }
 
-          let action
           if (sep === '|') {
-            action = ACTION_CHANGED
+            prevLines.push(prev.trimEnd())
+            currLines.push(curr.trimEnd())
           } else if (sep === '<') {
-            action = ACTION_REMOVED
+            prevLines.push(prev.trimEnd())
           } else if (sep === '>') {
-            action = ACTION_ADDED
+            currLines.push(curr.trimEnd())
           } else {
-            // Separator char belongs to current content (unchanged line)
-            curr = sep + curr
-            action = 0
+            prevLines.push(prev.trimEnd())
+            currLines.push(prev.trimEnd())
           }
-
-          rows.push({
-            line: i + 1,
-            previous: prev.trimEnd(),
-            current: curr.trimEnd(),
-            action,
-          })
         }
 
-        return rows
+        return { prevString: prevLines.join('\n'), currString: currLines.join('\n') }
       },
     },
   }
 </script>
-
-<style scoped>
-  .diff-legend-swatch {
-    display: inline-block;
-    width: 12px;
-    height: 12px;
-    border-radius: 2px;
-    margin-right: 4px;
-    border: 1px solid rgba(0, 0, 0, 0.15);
-  }
-</style>

--- a/untangle-vue-ui/source/src/components/reports/SettingsDiffDialog.vue
+++ b/untangle-vue-ui/source/src/components/reports/SettingsDiffDialog.vue
@@ -1,0 +1,257 @@
+<template>
+  <u-dialog
+    :show-dialog="value"
+    :title="dialogTitle"
+    :buttons="closeButton"
+    width="90%"
+    @close-dialog="$emit('input', false)"
+  >
+    <!-- Loading overlay — replaces UDialogComplex's :show-progress prop -->
+    <v-overlay v-if="loading" absolute color="rgba(255,255,255,0.66)" opacity="1" class="text-center">
+      <v-progress-circular indeterminate size="32" color="aristaMediumBlue" />
+    </v-overlay>
+
+    <!-- Error state -->
+    <div v-if="errorMessage" class="d-flex align-center justify-center py-4">
+      <v-alert type="warning" outlined max-width="500" class="ma-0">
+        {{ errorMessage }}
+      </v-alert>
+    </div>
+
+    <template v-else>
+      <!-- Color legend -->
+      <div class="d-flex align-center caption grey--text text--darken-1 mb-2" style="gap: 16px">
+        <span class="d-flex align-center">
+          <span class="diff-legend-swatch" style="background: #d9f5cb" />
+          {{ $t('added') }}
+        </span>
+        <span class="d-flex align-center">
+          <span class="diff-legend-swatch" style="background: #ffdfd9" />
+          {{ $t('removed') }}
+        </span>
+        <span class="d-flex align-center">
+          <span class="diff-legend-swatch" style="background: #ffff99" />
+          {{ $t('changed') }}
+        </span>
+      </div>
+
+      <!-- Diff grid — Line | Previous | Current columns.
+           d-flex flex-column is required so UGrid's inner flex-grow-1 has a flex context
+           and AG-Grid receives non-zero height from its parent. -->
+      <div class="d-flex flex-column" style="height: 60vh">
+        <u-grid
+          id="settings-diff-grid"
+          :column-defs="columnDefs"
+          :row-data="diffRows"
+          toolbar="hidden"
+          :custom-grid-options="gridOptions"
+          :custom-default-col-options="defaultColOptions"
+        />
+      </div>
+    </template>
+  </u-dialog>
+</template>
+
+<script>
+  import { UDialog, UGrid } from 'vuntangle'
+  import { VAlert, VOverlay, VProgressCircular } from 'vuetify/lib'
+  import Rpc from '@/util/Rpc'
+  import Util from '@/util/setupUtil'
+
+  // Diff action codes
+  const ACTION_ADDED = 1 // '>' line only in current  → green
+  const ACTION_REMOVED = 2 // '<' line only in previous → red
+  const ACTION_CHANGED = 3 // '|' line differs          → yellow
+
+  // Row background colors
+  const ROW_COLORS = {
+    [ACTION_ADDED]: '#d9f5cb',
+    [ACTION_REMOVED]: '#ffdfd9',
+    [ACTION_CHANGED]: '#ffff99',
+  }
+
+  export default {
+    name: 'SettingsDiffDialog',
+
+    components: { UDialog, UGrid, VAlert, VOverlay, VProgressCircular },
+
+    props: {
+      // v-model — controls dialog open/close
+      value: { type: Boolean, default: false },
+      // Full settings_file path from the settings_changes row
+      fileName: { type: String, default: '' },
+    },
+
+    data() {
+      return {
+        loading: false,
+        errorMessage: '',
+        diffRows: [],
+      }
+    },
+
+    computed: {
+      // Single Close button passed to UDialog's buttons array — removes the default OK button
+      closeButton() {
+        return [{ name: this.$t('close'), handler: 'close-dialog' }]
+      },
+
+      // Title shows the stripped file name for context
+      dialogTitle() {
+        const stripped = this.fileName.replace(/^.*\/settings\//, '').replace(/^.*\/conf\//, '')
+        return stripped ? `${this.$t('settings_difference')} — ${stripped}` : this.$t('settings_difference')
+      },
+
+      columnDefs() {
+        return [
+          {
+            field: 'line',
+            headerName: this.$t('line'),
+            width: 70,
+            flex: 0,
+            sortable: false,
+            filter: false,
+            suppressMenu: true,
+          },
+          {
+            field: 'previous',
+            headerName: this.$t('previous'),
+            flex: 1,
+            sortable: false,
+            filter: false,
+            suppressMenu: true,
+          },
+          {
+            field: 'current',
+            headerName: this.$t('current'),
+            flex: 1,
+            sortable: false,
+            filter: false,
+            suppressMenu: true,
+          },
+        ]
+      },
+
+      // Row color by action code
+      gridOptions() {
+        return {
+          getRowStyle: ({ data }) => {
+            const color = ROW_COLORS[data?.action]
+            return color ? { background: color } : null
+          },
+        }
+      },
+
+      // Monospace font + white-space: pre for diff content.
+      // AG-Grid renders text not HTML, so white-space: pre preserves indentation.
+      defaultColOptions() {
+        return {
+          cellStyle: { fontFamily: 'monospace', fontSize: '12px', whiteSpace: 'pre' },
+        }
+      },
+    },
+
+    watch: {
+      // Trigger diff fetch when dialog opens with a fileName
+      value(open) {
+        if (open && this.fileName) {
+          this.fetchDiff()
+        } else if (!open) {
+          this.reset()
+        }
+      },
+    },
+
+    methods: {
+      reset() {
+        this.diffRows = []
+        this.errorMessage = ''
+        this.loading = false
+      },
+
+      async fetchDiff() {
+        this.reset()
+        this.loading = true
+        try {
+          // Full dot-path: rpc.settingsManager → getDiff method
+          const result = await Rpc.asyncData('rpc.settingsManager.getDiff', this.fileName)
+          this.diffRows = this.parseDiff(result || '')
+        } catch (err) {
+          const msg = err?.message || ''
+          if (msg.includes('Could not find an earlier file')) {
+            this.errorMessage = this.$t('settings_no_previous_version')
+          } else if (msg.includes('too big to compare')) {
+            this.errorMessage = this.$t('settings_too_large_to_compare')
+          } else {
+            Util.handleException(err)
+            this.errorMessage = this.$t('error')
+          }
+        } finally {
+          this.loading = false
+        }
+      },
+
+      /**
+       * Parses the raw output of: diff -y -W1024 -t <previous> <current>
+       *
+       * Side-by-side format with -W1024:
+       *   char 0:      part of previous content (unless '<' or '>')
+       *   chars 1–510: rest of previous content (510 chars)
+       *   char 511:    separator: ' '=unchanged | '|'=changed | '<'=removed | '>'=added
+       *   chars 512+:  current content
+       */
+      parseDiff(raw) {
+        const rows = []
+        const lines = raw.split('\n')
+
+        for (let i = 0; i < lines.length; i++) {
+          const line = lines[i]
+          if (!line) continue
+
+          const prevMarker = line.substring(0, 1)
+          let prev = line.substring(1, 511)
+          const sep = line.substring(511, 512)
+          let curr = line.substring(512)
+
+          // If char 0 is not a diff side-marker, it is part of previous content
+          if (prevMarker !== '<' && prevMarker !== '>') {
+            prev = prevMarker + prev
+          }
+
+          let action
+          if (sep === '|') {
+            action = ACTION_CHANGED
+          } else if (sep === '<') {
+            action = ACTION_REMOVED
+          } else if (sep === '>') {
+            action = ACTION_ADDED
+          } else {
+            // Separator char belongs to current content (unchanged line)
+            curr = sep + curr
+            action = 0
+          }
+
+          rows.push({
+            line: i + 1,
+            previous: prev.trimEnd(),
+            current: curr.trimEnd(),
+            action,
+          })
+        }
+
+        return rows
+      },
+    },
+  }
+</script>
+
+<style scoped>
+  .diff-legend-swatch {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 2px;
+    margin-right: 4px;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+  }
+</style>

--- a/untangle-vue-ui/source/src/store/config.js
+++ b/untangle-vue-ui/source/src/store/config.js
@@ -43,6 +43,15 @@ const getters = {
   interface: state => device => {
     return state.networkSetting?.interfaces?.find(intf => intf.device === device)
   },
+  interfaceNameMap: state => {
+    const map = {}
+    ;(state.networkSetting?.interfaces || []).forEach(intf => {
+      if (intf.interfaceId != null) {
+        map[intf.interfaceId] = intf.name ? `${intf.name} [${intf.interfaceId}]` : String(intf.interfaceId)
+      }
+    })
+    return map
+  },
   systemSetting: state => state.systemSetting || {},
   eventSettings: state => state.eventSettings || {},
   templateParameters: state => state.templateParameters || [],

--- a/untangle-vue-ui/source/src/store/reports.js
+++ b/untangle-vue-ui/source/src/store/reports.js
@@ -33,6 +33,9 @@ const getDefaultState = () => ({
 
   // Timestamp of last load (for cache invalidation if needed)
   lastLoaded: null,
+
+  // Policy list from backend — populated lazily on first EVENT_LIST view
+  policiesInfo: [],
 })
 
 const getters = {
@@ -74,6 +77,21 @@ const getters = {
   loading: state => state.loading,
   error: state => state.error,
   isLoaded: state => state.allReports.length > 0 || state.lastLoaded !== null,
+
+  /**
+   * Maps policy ID (integer) → "name [id]" display string.
+   * Populated lazily by fetchPoliciesInfo when an EVENT_LIST report is opened.
+   * Returns an empty map when no policy-manager is installed.
+   */
+  policyNameMap: state => {
+    const map = {}
+    state.policiesInfo.forEach(p => {
+      if (p.policyId != null) {
+        map[p.policyId] = p.name ? `${p.name} [${p.policyId}]` : String(p.policyId)
+      }
+    })
+    return map
+  },
 }
 
 const mutations = {
@@ -113,6 +131,10 @@ const mutations = {
 
   SET_LAST_LOADED(state, timestamp) {
     state.lastLoaded = timestamp
+  },
+
+  SET_POLICIES_INFO(state, policies) {
+    state.policiesInfo = policies
   },
 
   RESET(state) {
@@ -179,6 +201,22 @@ const actions = {
   },
 
   /**
+   * Fetches policy name/ID pairs from the backend for EVENT_LIST detail rendering.
+   * Only runs once — returns immediately if policiesInfo is already populated.
+   * Returns an empty list when no policy-manager is installed.
+   */
+  async fetchPoliciesInfo({ state, commit }) {
+    if (state.policiesInfo.length) return
+    if (!state.reportsManager) return
+    try {
+      const result = await Rpc.asyncData(state.reportsManager, 'getPoliciesInfo')
+      if (result?.list) commit('SET_POLICIES_INFO', result.list)
+    } catch (error) {
+      Util.handleException(error)
+    }
+  },
+
+  /**
    * Fetches report data from the backend for a given report entry and time range.
    *
    * The backend returns a type-aware JSONObject:
@@ -194,18 +232,28 @@ const actions = {
    * @param {Number} payload.limit       - maximum rows to return; -1 for unlimited
    * @returns {Object} backend payload with either a `data` key (chart) or `list` key (events)
    */
-  async fetchReportData({ state }, { entry, conditions = [], startDate, endDate, limit = -1 }) {
-    const result = await Rpc.asyncData(
-      state.reportsManager,
-      'getDataForReportEntryV2',
-      entry,
-      startDate,
-      endDate,
-      null,
-      conditions,
-      null,
-      limit,
-    )
+  async fetchReportData({ state, dispatch }, { entry, conditions = [], startDate, endDate, limit = -1 }) {
+    const callRpc = manager =>
+      Rpc.asyncData(manager, 'getDataForReportEntryV2', entry, startDate, endDate, null, conditions, null, limit)
+
+    let result
+    try {
+      result = await callRpc(state.reportsManager)
+    } catch (error) {
+      // Jabsorb session can expire after inactivity, making the cached reportsManager
+      // proxy invalid ("No such method"). Re-acquire the manager and retry once.
+      const isStaleProxy = error?.message?.includes('No such method') || error?.message?.includes('no such object')
+
+      if (!isStaleProxy) {
+        Util.handleException(error)
+        return { list: [] }
+      }
+
+      // Re-initialise the reports manager and retry the request
+      await dispatch('loadReports')
+      result = await callRpc(state.reportsManager)
+    }
+
     if (!result) return { list: [] }
 
     // Chart types return { series: [...] } or { slices: [...] } at the root level

--- a/untangle-vue-ui/source/src/util/eventTableColumns.js
+++ b/untangle-vue-ui/source/src/util/eventTableColumns.js
@@ -1,0 +1,1107 @@
+/**
+ * NGFW event table column registry.
+ *
+ * Provides:
+ *  - tableFields  — ordered field list per table
+ *  - FIELD_META    — rendering metadata per field (width, valueFormatter, sort)
+ *  - buildEventColumnDefs(table, defaultColumns) — builds AG-Grid column def array
+ *
+ * Column headers are resolved via i18n.t(field) at build time.
+ */
+
+import i18n from '@/plugins/vue-i18n'
+import { protocolNameMap } from '@/constants'
+
+// ─── Static code→name maps ───────────────────────────────────────────────────
+
+// bandwidth_control_priority 0–7 → en.js i18n keys; 0 = no priority assigned → null (formatter returns '')
+export const priorityMap = {
+  0: null,
+  1: 'very_high',
+  2: 'high',
+  3: 'medium',
+  4: 'low',
+  5: 'limited',
+  6: 'limited_more',
+  7: 'limited_severely',
+}
+
+// admin_logins.reason codes → en.js i18n keys.
+// Not in FIELD_META because reason also appears in quotas table as a readable string.
+// Applied table-specifically inside buildEventColumnDefs.
+export const loginReasonMap = {
+  U: 'invalid_username',
+  P: 'invalid_password',
+  T: 'invalid_totp',
+  I: 'logged_in_successfully',
+  O: 'logged_out_successfully',
+}
+
+// spam/phish blocker action codes → en.js i18n keys
+export const emailActionMap = {
+  P: 'pass_message',
+  M: 'mark_message',
+  D: 'drop_message',
+  B: 'block_message',
+  Q: 'quarantine_message',
+  S: 'pass_safelist_message',
+  Z: 'pass_oversize_message',
+  O: 'pass_outbound_message',
+  F: 'block_message_scan_failure',
+  G: 'pass_message_scan_failure',
+  Y: 'block_message_greylist',
+}
+
+// web_filter_reason single-char codes → en.js i18n keys
+// Unknown codes fall back to 'no_rule_applied'
+export const webFilterReasonMap = {
+  D: 'in_categories_block_list',
+  U: 'in_site_block_list',
+  T: 'in_search_term_list',
+  E: 'in_file_block_list',
+  M: 'in_mime_types_block_list',
+  H: 'hostname_is_an_ip_address',
+  I: 'in_site_pass_list',
+  R: 'referer_in_site_pass_list',
+  C: 'in_clients_pass_list',
+  B: 'in_temporary_unblocked_list',
+  F: 'in_rules_list',
+  K: 'kid_friendly_redirect',
+}
+
+// HTTP method single-char code → full name; unknown → raw value
+export const httpMethodMap = {
+  O: 'OPTIONS (O)',
+  G: 'GET (G)',
+  H: 'HEAD (H)',
+  P: 'POST (P)',
+  U: 'PUT (U)',
+  D: 'DELETE (D)',
+  T: 'TRACE (T)',
+  C: 'CONNECT (C)',
+  X: 'NON-STANDARD (X)',
+}
+
+// captive_portal_user_events.auth_type → readable string
+export const authTypeMap = {
+  NONE: 'None',
+  LOCAL_DIRECTORY: 'Local Directory',
+  ACTIVE_DIRECTORY: 'Active Directory',
+  RADIUS: 'RADIUS',
+  GOOGLE: 'Google Account',
+  MICROSOFT: 'Microsoft Account',
+  CUSTOM: 'Custom',
+}
+
+// captive_portal_user_events.event_info → readable string
+export const captivePortalEventMap = {
+  LOGIN: 'Login Success',
+  FAILED: 'Login Failure',
+  TIMEOUT: 'Session Timeout',
+  INACTIVE: 'Idle Timeout',
+  USER_LOGOUT: 'User Logout',
+  ADMIN_LOGOUT: 'Admin Logout',
+  HOST_CHANGE: 'Host Change Logout',
+}
+
+// quotas.action — 1→'Given', 2→'Exceeded' (table-specific: applied via tableMeta for 'quotas')
+// Note: wan_failover_action_events also has an 'action' field with different string values
+export const quotaActionMap = {
+  1: 'Given',
+  2: 'Exceeded',
+}
+
+// directory_connector_login_events.type — I/U/O/A → login/update/logout/authenticate (table-specific)
+// Note: other VPN event tables use 'type' with already-readable values — no conversion needed
+export const directoryConnectorActionMap = {
+  I: 'login',
+  U: 'update',
+  O: 'logout',
+  A: 'authenticate',
+}
+
+// Threat prevention category bitmask — each key is the BIT INDEX (not the bitmask value).
+// Use Math.pow(2, key) & value to test membership.
+export const threatCategoryMap = {
+  0: 'Spam Sources',
+  1: 'Windows Exploits',
+  2: 'Web Attacks',
+  3: 'Botnets',
+  4: 'Scanners',
+  5: 'Denial of Service',
+  6: 'Reputation',
+  7: 'Phishing',
+  8: 'Proxy',
+  11: 'Mobile Threats',
+  13: 'Tor Proxy',
+  16: 'Keyloggers',
+  17: 'Malware',
+  18: 'Spyware',
+}
+
+// Decodes threat category bitmask into comma-separated category names; 0 → ''
+export function decodeThreatCategories(value) {
+  if (!value) return ''
+  const bits = Object.keys(threatCategoryMap)
+  return bits
+    .filter(bit => Math.pow(2, Number(bit)) & value)
+    .map(bit => threatCategoryMap[bit])
+    .join(', ')
+}
+
+// icmp_type integer → IANA ICMP type name; exported so detailFormatters share the same map.
+// Fallback 'Unassigned' for null/unknown values.
+export const icmpTypeMap = {
+  0: 'Echo Reply',
+  1: 'Unassigned',
+  2: 'Unassigned',
+  3: 'Destination Unreachable',
+  4: 'Source Quench (Deprecated)',
+  5: 'Redirect',
+  6: 'Alternate Host Address (Deprecated)',
+  7: 'Unassigned',
+  8: 'Echo',
+  9: 'Router Advertisement',
+  10: 'Router Solicitation',
+  11: 'Time Exceeded',
+  12: 'Parameter Problem',
+  13: 'Timestamp',
+  14: 'Timestamp Reply',
+  15: 'Information Request (Deprecated)',
+  16: 'Information Reply (Deprecated)',
+  17: 'Address Mask Request (Deprecated)',
+  18: 'Address Mask Reply (Deprecated)',
+  19: 'Reserved (for Security)',
+  20: 'Reserved (for Robustness Experiment)',
+  21: 'Reserved (for Robustness Experiment)',
+  22: 'Reserved (for Robustness Experiment)',
+  23: 'Reserved (for Robustness Experiment)',
+  24: 'Reserved (for Robustness Experiment)',
+  25: 'Reserved (for Robustness Experiment)',
+  26: 'Reserved (for Robustness Experiment)',
+  27: 'Reserved (for Robustness Experiment)',
+  28: 'Reserved (for Robustness Experiment)',
+  29: 'Reserved (for Robustness Experiment)',
+  30: 'Traceroute (Deprecated)',
+  31: 'Datagram Conversion Error (Deprecated)',
+  32: 'Mobile Host Redirect (Deprecated)',
+  33: 'IPv6 Where-Are-You (Deprecated)',
+  34: 'IPv6 I-Am-Here (Deprecated)',
+  35: 'Mobile Registration Request (Deprecated)',
+  36: 'Mobile Registration Reply (Deprecated)',
+  37: 'Domain Name Request (Deprecated)',
+  38: 'Domain Name Reply (Deprecated)',
+  39: 'SKIP (Deprecated)',
+  40: 'Photuris',
+  41: 'ICMP messages utilized by experimental mobility protocols',
+  253: 'RFC3692-style Experiment 1',
+  254: 'RFC3692-style Experiment 2',
+}
+
+// Static lookup table that maps web filter category IDs (integers) to human-readable category names.
+// Used by the web_filter_category_id column formatter and details panel renderer.
+// Unknown IDs fall back to the raw numeric string; null is handled by the caller.
+export const webCategoryMap = {
+  0: 'Uncategorized',
+  1: 'Real Estate',
+  2: 'Computer and Internet Security',
+  3: 'Financial Services',
+  4: 'Business and Economy',
+  5: 'Computer and Internet Info',
+  6: 'Auctions',
+  7: 'Shopping',
+  8: 'Cult and Occult',
+  9: 'Travel',
+  10: 'Abused Drugs',
+  11: 'Adult and Pornography',
+  12: 'Home and Garden',
+  13: 'Military',
+  14: 'Social Networking',
+  15: 'Dead Sites',
+  16: 'Individual Stock Advice and Tools',
+  17: 'Training and Tools',
+  18: 'Dating',
+  19: 'Sex Education',
+  20: 'Religion',
+  21: 'Entertainment and Arts',
+  22: 'Personal sites and Blogs',
+  23: 'Legal',
+  24: 'Local Information',
+  25: 'Streaming Media',
+  26: 'Job Search',
+  27: 'Gambling',
+  28: 'Translation',
+  29: 'Reference and Research',
+  30: 'Shareware and Freeware',
+  31: 'Peer to Peer',
+  32: 'Marijuana',
+  33: 'Hacking',
+  34: 'Games',
+  35: 'Philosophy and Political Advocacy',
+  36: 'Weapons',
+  37: 'Pay to Surf',
+  38: 'Hunting and Fishing',
+  39: 'Society',
+  40: 'Educational Institutions',
+  41: 'Online Greeting Cards',
+  42: 'Sports',
+  43: 'Swimsuits and Intimate Apparel',
+  44: 'Questionable',
+  45: 'Kids',
+  46: 'Hate and Racism',
+  47: 'Personal Storage',
+  48: 'Violence',
+  49: 'Keyloggers and Monitoring',
+  50: 'Search Engines',
+  51: 'Internet Portals',
+  52: 'Web Advertisements',
+  53: 'Cheating',
+  54: 'Gross',
+  55: 'Web-based Email',
+  56: 'Malware Sites',
+  57: 'Phishing and Other Frauds',
+  58: 'Proxy Avoidance and Anonymizers',
+  59: 'Spyware and Adware',
+  60: 'Music',
+  61: 'Government',
+  62: 'Nudity',
+  63: 'News and Media',
+  64: 'Illegal',
+  65: 'Content Delivery Networks',
+  66: 'Internet Communications',
+  67: 'Bot Nets',
+  68: 'Abortion',
+  69: 'Health and Medicine',
+  71: 'SPAM URLs',
+  74: 'Dynamically Generated Content',
+  75: 'Parked Domains',
+  76: 'Alcohol and Tobacco',
+  78: 'Image and Video Search',
+  79: 'Fashion and Beauty',
+  80: 'Recreation and Hobbies',
+  81: 'Motor Vehicles',
+  82: 'Web Hosting',
+}
+
+// Boolean formatter — null/undefined (SQL NULL absent from row) → 'false', true → 'true', false → 'false'
+const boolFormatter = ({ value }) => (value == null ? 'false' : value ? 'true' : 'false')
+
+// ─── Rendering metadata ─────────────────────────────────────────────────────
+// Only fields that need special width, sort, or valueFormatter are listed.
+// All other fields get { flex: 1 } from buildEventColumnDefs.
+
+const FIELD_META = {
+  // time_stamp and second-based timestamps have timezone-aware formatters
+  // built dynamically in buildEventColumnDefs using tzOffsetMs.
+  time_stamp: { width: 160, sort: 'desc' },
+  // Byte fields — human-readable sizes
+  c2p_bytes: { width: 100, valueFormatter: ({ value }) => formatBytes(value) },
+  c2s_bytes: { width: 100, valueFormatter: ({ value }) => formatBytes(value) },
+  s2c_bytes: { width: 100, valueFormatter: ({ value }) => formatBytes(value) },
+  s2p_bytes: { width: 100, valueFormatter: ({ value }) => formatBytes(value) },
+  p2c_bytes: { width: 100, valueFormatter: ({ value }) => formatBytes(value) },
+  p2s_bytes: { width: 100, valueFormatter: ({ value }) => formatBytes(value) },
+  in_bytes: { width: 100, valueFormatter: ({ value }) => formatBytes(value) },
+  out_bytes: { width: 100, valueFormatter: ({ value }) => formatBytes(value) },
+  rx_bytes: { width: 100, valueFormatter: ({ value }) => formatBytes(value) },
+  tx_bytes: { width: 100, valueFormatter: ({ value }) => formatBytes(value) },
+  hit_bytes: { width: 100, valueFormatter: ({ value }) => formatBytes(value) },
+  miss_bytes: { width: 100, valueFormatter: ({ value }) => formatBytes(value) },
+  // Protocol — number → display name
+  protocol: {
+    width: 90,
+    valueFormatter: ({ value }) => protocolNameMap[value] ?? String(value ?? ''),
+  },
+  // Generic boolean fields — null/undefined (SQL NULL) → 'false', true → 'true'
+  blocked: { width: 80, valueFormatter: boolFormatter },
+  flagged: { width: 80, valueFormatter: boolFormatter },
+  bypassed: { width: 80, valueFormatter: boolFormatter },
+  entitled: { width: 80, valueFormatter: boolFormatter },
+  success: { width: 80, valueFormatter: boolFormatter },
+
+  // ICMP type number → IANA name; null/unknown → 'Unassigned' (even for TCP/UDP rows)
+  icmp_type: { width: 150, valueFormatter: ({ value }) => icmpTypeMap[value] ?? 'Unassigned' },
+
+  // HTTP method single-char code → full name; used in http_events, ftp_events, http_query_events
+  method: { width: 80, valueFormatter: ({ value }) => (value == null ? '' : httpMethodMap[value] ?? String(value)) },
+
+  // captive_portal auth_type → readable string; unknown → 'Unknown'
+  auth_type: { width: 150, valueFormatter: ({ value }) => (value == null ? '' : authTypeMap[value] ?? 'Unknown') },
+
+  // captive_portal event_info → readable string; null/'' → '', unknown → 'Unknown'
+  event_info: {
+    width: 150,
+    valueFormatter: ({ value }) => (value == null || value === '' ? '' : captivePortalEventMap[value] ?? 'Unknown'),
+  },
+
+  // App-specific boolean fields — null/undefined → 'false', true → 'true'
+  firewall_blocked: { width: 80, valueFormatter: boolFormatter },
+  firewall_flagged: { width: 80, valueFormatter: boolFormatter },
+  application_control_blocked: { width: 80, valueFormatter: boolFormatter },
+  application_control_flagged: { width: 80, valueFormatter: boolFormatter },
+  application_control_lite_blocked: { width: 80, valueFormatter: boolFormatter },
+  captive_portal_blocked: { width: 80, valueFormatter: boolFormatter },
+  phish_blocker_is_spam: { width: 80, valueFormatter: boolFormatter },
+  spam_blocker_is_spam: { width: 80, valueFormatter: boolFormatter },
+  spam_blocker_lite_is_spam: { width: 80, valueFormatter: boolFormatter },
+  virus_blocker_clean: { width: 80, valueFormatter: boolFormatter },
+  virus_blocker_lite_clean: { width: 80, valueFormatter: boolFormatter },
+  web_filter_blocked: { width: 80, valueFormatter: boolFormatter },
+  web_filter_flagged: { width: 80, valueFormatter: boolFormatter },
+  threat_prevention_blocked: { width: 80, valueFormatter: boolFormatter },
+  threat_prevention_flagged: { width: 80, valueFormatter: boolFormatter },
+  // Server load fields
+  load_1: { width: 100 },
+  load_5: { width: 80 },
+  load_15: { width: 80 },
+  // Numeric rate fields
+  rx_rate: { width: 100 },
+  tx_rate: { width: 100 },
+  // JSON field (alerts table) — backend HTML-encodes embedded quotes; decode explicitly for AG-Grid text nodes
+  json: {
+    flex: 1,
+    valueFormatter: ({ value }) => {
+      if (!value) return ''
+      const s = String(value)
+      return s
+        .replace(/&quot;/g, '"')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&#39;/g, "'")
+    },
+  },
+  // Wide text fields
+  uri: { width: 250 },
+  host: { width: 200 },
+  domain: { width: 180 },
+  description: { width: 200 },
+  summary_text: { width: 200 },
+  msg: { width: 180 },
+  operation: { width: 200 },
+  // connect/goodbye/start/end are java.sql.Timestamp in DB — normalizeTimestampsInRow converts to epoch ms
+  connect_stamp: { width: 150 },
+  goodbye_stamp: { width: 150 },
+  start_time: { width: 150 },
+  end_time: { width: 150 },
+  // Boolean fields with human-readable labels
+  local: { width: 80, valueFormatter: ({ value }) => (value ? 'local' : 'remote') },
+  succeeded: { width: 80, valueFormatter: ({ value }) => (value ? 'success' : 'failed') },
+
+  // bandwidth_control_priority 0-7 → i18n Title Case name; 0/null → '' (no priority assigned)
+  bandwidth_control_priority: {
+    width: 120,
+    valueFormatter: ({ value }) => (priorityMap[value] ? i18n.t(priorityMap[value]) : ''),
+  },
+
+  // bandwidth_control_rule — 0/null → 'None', else raw rule number
+  bandwidth_control_rule: {
+    width: 120,
+    valueFormatter: ({ value }) => (value == null || value === 0 ? i18n.t('none') : String(value)),
+  },
+
+  // ad_blocker_action — 'B' → 'Block', else 'Pass'; null/'' → ''
+  ad_blocker_action: {
+    width: 80,
+    valueFormatter: ({ value }) =>
+      value == null || value === '' ? '' : value === 'B' ? i18n.t('block') : i18n.t('pass'),
+  },
+
+  // spam/phish blocker action codes → i18n label + code (e.g. "Pass Message [P]"); null/'' → '', unknown → 'Unknown Action [code]'
+  spam_blocker_action: {
+    valueFormatter: ({ value }) =>
+      value == null || value === ''
+        ? ''
+        : emailActionMap[value]
+        ? `${i18n.t(emailActionMap[value])} [${value}]`
+        : `${i18n.t('unknown_action')} [${value}]`,
+  },
+  spam_blocker_lite_action: {
+    valueFormatter: ({ value }) =>
+      value == null || value === ''
+        ? ''
+        : emailActionMap[value]
+        ? `${i18n.t(emailActionMap[value])} [${value}]`
+        : `${i18n.t('unknown_action')} [${value}]`,
+  },
+  phish_blocker_action: {
+    valueFormatter: ({ value }) =>
+      value == null || value === ''
+        ? ''
+        : emailActionMap[value]
+        ? `${i18n.t(emailActionMap[value])} [${value}]`
+        : `${i18n.t('unknown_action')} [${value}]`,
+  },
+
+  // Memory fields — always MB, no auto-scaling
+  mem_free: { width: 100, valueFormatter: ({ value }) => formatMemoryMB(value) },
+  mem_total: { width: 100, valueFormatter: ({ value }) => formatMemoryMB(value) },
+  swap_free: { width: 100, valueFormatter: ({ value }) => formatMemoryMB(value) },
+  swap_total: { width: 100, valueFormatter: ({ value }) => formatMemoryMB(value) },
+
+  // Disk fields — always GB, no auto-scaling
+  disk_free: { width: 100, valueFormatter: ({ value }) => formatDiskGB(value) },
+  disk_total: { width: 100, valueFormatter: ({ value }) => formatDiskGB(value) },
+
+  // web_filter_reason code → readable label; null/unknown → 'No Rule Applied'
+  web_filter_reason: {
+    valueFormatter: ({ value }) =>
+      webFilterReasonMap[value] ? i18n.t(webFilterReasonMap[value]) : i18n.t('no_rule_applied'),
+  },
+
+  // Renders web_filter_category_id as a human-readable category name using webCategoryMap.
+  // null renders as empty string; unknown IDs fall back to the raw numeric string.
+  web_filter_category_id: {
+    valueFormatter: ({ value }) => (value == null ? '' : webCategoryMap[value] ?? String(value)),
+  },
+
+  // Threat prevention reason — same lookup as web_filter_reason; null/unknown → 'No Rule Applied'
+  threat_prevention_reason: {
+    valueFormatter: ({ value }) =>
+      webFilterReasonMap[value] ? i18n.t(webFilterReasonMap[value]) : i18n.t('no_rule_applied'),
+  },
+
+  // Threat prevention rule ID — 0/null → '' (no rule assigned); else raw numeric ID
+  threat_prevention_rule_id: {
+    width: 120,
+    valueFormatter: ({ value }) => (value == null || value === 0 ? '' : String(value)),
+  },
+
+  // Threat prevention category bitmask → comma-separated category names
+  threat_prevention_client_categories: {
+    width: 150,
+    valueFormatter: ({ value }) => decodeThreatCategories(value),
+  },
+  threat_prevention_server_categories: {
+    width: 150,
+    valueFormatter: ({ value }) => decodeThreatCategories(value),
+  },
+
+  // Threat prevention reputation score — 0/null → '', else raw score
+  threat_prevention_client_reputation: {
+    width: 150,
+    valueFormatter: ({ value }) => (value == null || value === 0 ? '' : String(value)),
+  },
+  threat_prevention_server_reputation: {
+    width: 150,
+    valueFormatter: ({ value }) => (value == null || value === 0 ? '' : String(value)),
+  },
+
+  // Tags — JSON object { list: [{name}] } or raw JSON string; join tag names with space
+  tags: {
+    valueFormatter: ({ value }) => {
+      if (!value) return ''
+      try {
+        const parsed = typeof value === 'string' ? JSON.parse(value) : value
+        if (parsed?.list?.length > 0) {
+          return parsed.list
+            .map(t => String(t.name || '').trim())
+            .filter(Boolean)
+            .join(' ')
+        }
+      } catch {}
+      return ''
+    },
+  },
+
+  // Settings file path — strip the leading /usr/share/untangle/settings/ prefix
+  settings_file: {
+    width: 200,
+    valueFormatter: ({ value }) =>
+      String(value ?? '')
+        .replace(/^.*\/settings\//, '')
+        .replace(/^.*\/conf\//, ''),
+  },
+
+  // Address fields
+  c_client_addr: { width: 130 },
+  c_server_addr: { width: 130 },
+  s_client_addr: { width: 130 },
+  s_server_addr: { width: 130 },
+  c_client_port: { width: 110 },
+  c_server_port: { width: 110 },
+  s_client_port: { width: 110 },
+  s_server_port: { width: 110 },
+  source_addr: { width: 130 },
+  dest_addr: { width: 130 },
+  remote_addr: { width: 130 },
+  local_addr: { width: 130 },
+  peer_address: { width: 130 },
+  pool_address: { width: 130 },
+  client_addr: { width: 130 },
+  address: { width: 130 },
+}
+
+// ─── Null defaults ──────────────────────────────────────────────────────────
+// When a field is SQL NULL it is absent from the row object.
+// These defaults ensure the details panel shows false/0 for boolean/integer fields
+// instead of empty string, matching the model field type definitions.
+export const fieldNullDefaults = {
+  // Boolean fields (fld: { type: 'boolean' }) → false
+  blocked: false,
+  bypassed: false,
+  entitled: false,
+  flagged: false,
+  local: false,
+  succeeded: false,
+  success: false,
+  application_control_blocked: false,
+  application_control_flagged: false,
+  application_control_lite_blocked: false,
+  captive_portal_blocked: false,
+  firewall_blocked: false,
+  firewall_flagged: false,
+  phish_blocker_is_spam: false,
+  spam_blocker_is_spam: false,
+  spam_blocker_lite_is_spam: false,
+  virus_blocker_clean: false,
+  virus_blocker_lite_clean: false,
+  web_filter_blocked: false,
+  web_filter_flagged: false,
+  threat_prevention_blocked: false,
+  threat_prevention_flagged: false,
+  // Integer/number app rule ID and score fields (fld: { type: 'integer' }) → 0
+  application_control_ruleid: 0,
+  application_control_confidence: 0,
+  firewall_rule_index: 0,
+  captive_portal_rule_index: 0,
+  bandwidth_control_priority: 0,
+  bandwidth_control_rule: 0,
+  ssl_inspector_ruleid: 0,
+  web_filter_rule_id: 0,
+  policy_id: 0,
+  policy_rule_id: 0,
+  threat_prevention_rule_id: 0,
+  threat_prevention_client_reputation: 0,
+  threat_prevention_client_categories: 0,
+  threat_prevention_server_reputation: 0,
+  threat_prevention_server_categories: 0,
+}
+
+// ─── Table → ordered field list ─────────────────────────────────────────────
+// Field names are actual DB column names.
+
+export const tableFields = {
+  admin_logins: ['time_stamp', 'login', 'local', 'client_addr', 'succeeded', 'reason'],
+  alerts: ['time_stamp', 'description', 'summary_text', 'json'],
+  captive_portal_user_events: [
+    'time_stamp',
+    'policy_id',
+    'event_id',
+    'login_name',
+    'event_info',
+    'auth_type',
+    'client_addr',
+  ],
+  configuration_backup_events: ['time_stamp', 'success', 'description', 'destination', 'event_id'],
+  device_table_updates: ['time_stamp', 'mac_address', 'key', 'value', 'old_value'],
+  directory_connector_login_events: ['time_stamp', 'login_name', 'domain', 'type', 'client_addr'],
+  ftp_events: [
+    'time_stamp',
+    'event_id',
+    'session_id',
+    'client_intf',
+    'server_intf',
+    'c_client_addr',
+    's_client_addr',
+    'c_server_addr',
+    's_server_addr',
+    'policy_id',
+    'username',
+    'hostname',
+    'request_id',
+    'method',
+    'uri',
+  ],
+  host_table_updates: ['time_stamp', 'address', 'key', 'value', 'old_value'],
+  interface_stat_events: ['time_stamp', 'interface_id', 'rx_rate', 'rx_bytes', 'tx_rate', 'tx_bytes'],
+  ipsec_user_events: [
+    'event_id',
+    'time_stamp',
+    'connect_stamp',
+    'goodbye_stamp',
+    'client_address',
+    'client_protocol',
+    'client_username',
+    'net_process',
+    'net_interface',
+    'elapsed_time',
+    'rx_bytes',
+    'tx_bytes',
+  ],
+  ipsec_vpn_events: ['event_id', 'time_stamp', 'local_address', 'remote_address', 'tunnel_description', 'event_type'],
+  ipsec_tunnel_stats: ['time_stamp', 'tunnel_name', 'in_bytes', 'out_bytes', 'event_id'],
+  wireguard_vpn_stats: ['time_stamp', 'tunnel_name', 'peer_address', 'in_bytes', 'out_bytes', 'event_id'],
+  wireguard_vpn_events: ['event_id', 'time_stamp', 'tunnel_name', 'event_type'],
+  intrusion_prevention_events: [
+    'time_stamp',
+    'sig_id',
+    'gen_id',
+    'class_id',
+    'source_addr',
+    'source_port',
+    'dest_addr',
+    'dest_port',
+    'protocol_name',
+    'blocked',
+    'category',
+    'classtype',
+    'msg',
+    'rid',
+    'rule_id',
+  ],
+  openvpn_events: ['time_stamp', 'remote_address', 'pool_address', 'client_name', 'type'],
+  openvpn_stats: [
+    'time_stamp',
+    'start_time',
+    'end_time',
+    'rx_bytes',
+    'tx_bytes',
+    'remote_address',
+    'pool_address',
+    'remote_port',
+    'client_name',
+    'event_id',
+  ],
+  quotas: ['time_stamp', 'entity', 'action', 'size', 'reason'],
+  server_events: [
+    'time_stamp',
+    'load_1',
+    'load_5',
+    'load_15',
+    'cpu_user',
+    'cpu_system',
+    'mem_total',
+    'mem_free',
+    'disk_total',
+    'disk_free',
+    'swap_total',
+    'swap_free',
+    'active_hosts',
+  ],
+  settings_changes: ['time_stamp', 'settings_file', 'username', 'hostname'],
+  system_operations: ['time_stamp', 'operation', 'username', 'hostname'],
+  critical_alerts: ['time_stamp', 'component', 'message', 'problem'],
+  smtp_tarpit_events: ['time_stamp', 'ipaddr', 'hostname', 'policy_id', 'vendor_name', 'event_id'],
+  tunnel_vpn_events: ['event_id', 'time_stamp', 'tunnel_name', 'server_address', 'local_address', 'event_type'],
+  tunnel_vpn_stats: ['time_stamp', 'tunnel_name', 'in_bytes', 'out_bytes', 'event_id'],
+  user_table_updates: ['time_stamp', 'username', 'key', 'value', 'old_value'],
+  wan_failover_action_events: ['time_stamp', 'interface_id', 'action', 'os_name', 'name', 'event_id'],
+  wan_failover_test_events: ['time_stamp', 'interface_id', 'name', 'description', 'success', 'event_id'],
+  web_cache_stats: ['time_stamp', 'hits', 'misses', 'bypasses', 'systems', 'hit_bytes', 'miss_bytes', 'event_id'],
+  http_events: [
+    'request_id',
+    'time_stamp',
+    'session_id',
+    'client_intf',
+    'server_intf',
+    'c_client_addr',
+    's_client_addr',
+    'c_server_addr',
+    's_server_addr',
+    'c_client_port',
+    's_client_port',
+    'c_server_port',
+    's_server_port',
+    'client_country',
+    'client_latitude',
+    'client_longitude',
+    'server_country',
+    'server_latitude',
+    'server_longitude',
+    'policy_id',
+    'username',
+    'hostname',
+    'method',
+    'host',
+    'uri',
+    'domain',
+    'referer',
+    'c2s_content_length',
+    's2c_content_length',
+    's2c_content_type',
+    's2c_content_filename',
+    'ad_blocker_cookie_ident',
+    'ad_blocker_action',
+    'web_filter_reason',
+    'web_filter_category_id',
+    'web_filter_rule_id',
+    'web_filter_blocked',
+    'web_filter_flagged',
+    'virus_blocker_lite_clean',
+    'virus_blocker_lite_name',
+    'virus_blocker_clean',
+    'virus_blocker_name',
+    // Threat Prevention fields
+    'threat_prevention_blocked',
+    'threat_prevention_flagged',
+    'threat_prevention_reason',
+    'threat_prevention_rule_id',
+    'threat_prevention_client_reputation',
+    'threat_prevention_client_categories',
+    'threat_prevention_server_reputation',
+    'threat_prevention_server_categories',
+  ],
+  http_query_events: [
+    'event_id',
+    'time_stamp',
+    'session_id',
+    'client_intf',
+    'server_intf',
+    'c_client_addr',
+    's_client_addr',
+    'c_server_addr',
+    's_server_addr',
+    'c_client_port',
+    's_client_port',
+    'c_server_port',
+    's_server_port',
+    'policy_id',
+    'username',
+    'hostname',
+    'request_id',
+    'method',
+    'term',
+    'host',
+    'uri',
+    'c2s_content_length',
+    's2c_content_length',
+    's2c_content_type',
+    'blocked',
+    'flagged',
+    'web_filter_reason',
+  ],
+  mail_addrs: [
+    'time_stamp',
+    'session_id',
+    'server_intf',
+    'c_client_addr',
+    'c_server_addr',
+    'c_client_port',
+    'c_server_port',
+    's_client_addr',
+    's_server_addr',
+    's_client_port',
+    's_server_port',
+    'policy_id',
+    'username',
+    'msg_id',
+    'subject',
+    'addr',
+    'addr_name',
+    'addr_kind',
+    'hostname',
+    'event_id',
+    'sender',
+    'virus_blocker_lite_clean',
+    'virus_blocker_lite_name',
+    'virus_blocker_clean',
+    'virus_blocker_name',
+    'spam_blocker_lite_score',
+    'spam_blocker_lite_is_spam',
+    'spam_blocker_lite_action',
+    'spam_blocker_lite_tests_string',
+    'spam_blocker_score',
+    'spam_blocker_is_spam',
+    'spam_blocker_action',
+    'spam_blocker_tests_string',
+    'phish_blocker_score',
+    'phish_blocker_is_spam',
+    'phish_blocker_tests_string',
+    'phish_blocker_action',
+  ],
+  session_minutes: [
+    'session_id',
+    'time_stamp',
+    'c2s_bytes',
+    's2c_bytes',
+    'start_time',
+    'end_time',
+    'bypassed',
+    'entitled',
+    'protocol',
+    'icmp_type',
+    'hostname',
+    'username',
+    'policy_id',
+    'policy_rule_id',
+    'local_addr',
+    'remote_addr',
+    'c_client_addr',
+    'c_server_addr',
+    'c_client_port',
+    'c_server_port',
+    's_client_addr',
+    's_server_addr',
+    's_client_port',
+    's_server_port',
+    'client_intf',
+    'server_intf',
+    'client_country',
+    'client_latitude',
+    'client_longitude',
+    'server_country',
+    'server_latitude',
+    'server_longitude',
+    'filter_prefix',
+    'firewall_blocked',
+    'firewall_flagged',
+    'firewall_rule_index',
+    'application_control_lite_protocol',
+    'application_control_lite_blocked',
+    'captive_portal_blocked',
+    'captive_portal_rule_index',
+    'application_control_application',
+    'application_control_protochain',
+    'application_control_category',
+    'application_control_blocked',
+    'application_control_flagged',
+    'application_control_confidence',
+    'application_control_ruleid',
+    'application_control_detail',
+    'bandwidth_control_priority',
+    'bandwidth_control_rule',
+    'ssl_inspector_ruleid',
+    'ssl_inspector_status',
+    'ssl_inspector_detail',
+    // Threat Prevention fields
+    'threat_prevention_blocked',
+    'threat_prevention_flagged',
+    'threat_prevention_reason',
+    'threat_prevention_rule_id',
+    'threat_prevention_client_reputation',
+    'threat_prevention_client_categories',
+    'threat_prevention_server_reputation',
+    'threat_prevention_server_categories',
+    'tags',
+  ],
+  sessions: [
+    'session_id',
+    'time_stamp',
+    'end_time',
+    'bypassed',
+    'entitled',
+    'protocol',
+    'icmp_type',
+    'hostname',
+    'username',
+    'policy_id',
+    'policy_rule_id',
+    'local_addr',
+    'remote_addr',
+    'c_client_addr',
+    'c_server_addr',
+    'c_client_port',
+    'c_server_port',
+    's_client_addr',
+    's_server_addr',
+    's_client_port',
+    's_server_port',
+    'client_intf',
+    'server_intf',
+    'client_country',
+    'client_latitude',
+    'client_longitude',
+    'server_country',
+    'server_latitude',
+    'server_longitude',
+    'c2p_bytes',
+    'p2c_bytes',
+    's2p_bytes',
+    'p2s_bytes',
+    'filter_prefix',
+    'firewall_blocked',
+    'firewall_flagged',
+    'firewall_rule_index',
+    'application_control_lite_protocol',
+    'application_control_lite_blocked',
+    'captive_portal_blocked',
+    'captive_portal_rule_index',
+    'application_control_application',
+    'application_control_protochain',
+    'application_control_category',
+    'application_control_blocked',
+    'application_control_flagged',
+    'application_control_confidence',
+    'application_control_ruleid',
+    'application_control_detail',
+    'bandwidth_control_priority',
+    'bandwidth_control_rule',
+    'ssl_inspector_ruleid',
+    'ssl_inspector_status',
+    'ssl_inspector_detail',
+    // Threat Prevention fields
+    'threat_prevention_blocked',
+    'threat_prevention_flagged',
+    'threat_prevention_reason',
+    'threat_prevention_rule_id',
+    'threat_prevention_client_reputation',
+    'threat_prevention_client_categories',
+    'threat_prevention_server_reputation',
+    'threat_prevention_server_categories',
+    'tags',
+  ],
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function formatBytes(value) {
+  if (value === null || value === undefined) return ''
+  const n = Number(value)
+  if (n === 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  const i = Math.floor(Math.log(Math.abs(n)) / Math.log(1024))
+  return (n / Math.pow(1024, i)).toFixed(1) + ' ' + units[Math.min(i, units.length - 1)]
+}
+
+/**
+ * Formats a byte value as megabytes — always MB, no auto-scaling.
+ * Used for mem_free, mem_total, swap_free, swap_total.
+ */
+export function formatMemoryMB(value) {
+  if (value == null) return ''
+  const meg = Number(value) / 1024 / 1024
+  return `${Math.round(meg * 10) / 10} MB`
+}
+
+/**
+ * Formats a byte value as gigabytes — always GB, no auto-scaling.
+ * Used for disk_free, disk_total.
+ */
+export function formatDiskGB(value) {
+  if (value == null) return ''
+  const gig = Number(value) / 1024 / 1024 / 1024
+  return `${Math.round(gig * 10) / 10} GB`
+}
+
+/**
+ * Formats an epoch-ms timestamp as YYYY-MM-DD hh:mm:ss am/pm in server local time.
+ * Applies tzOffsetMs so the displayed time matches the server's timezone.
+ *
+ * @param {number} ms         - epoch milliseconds from the backend
+ * @param {number} tzOffsetMs - server timezone offset in ms
+ */
+function formatTimestamp(ms, tzOffsetMs = 0) {
+  if (!ms) return ''
+  const d = new Date(ms + tzOffsetMs)
+  const Y = d.getUTCFullYear()
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(d.getUTCDate()).padStart(2, '0')
+  let h = d.getUTCHours()
+  const min = String(d.getUTCMinutes()).padStart(2, '0')
+  const s = String(d.getUTCSeconds()).padStart(2, '0')
+  const ampm = h >= 12 ? 'pm' : 'am'
+  h = h % 12 || 12
+  return `${Y}-${m}-${dd} ${String(h).padStart(2, '0')}:${min}:${s} ${ampm}`
+}
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/**
+ * Builds an AG-Grid columnDefs array for the given event table.
+ *
+ * - Column order follows tableFields[table].
+ * - Columns in entry.defaultColumns are visible; all others are hidden.
+ * - headerName is resolved via i18n.t(field) at call time.
+ * - Timestamp formatters use tzOffsetMs to show server local time.
+ * - Special rendering (formatters, widths) comes from FIELD_META[field].
+ * - interfaceNameMap / policyNameMap are runtime-resolved maps for displaying
+ *   interface and policy names instead of raw IDs.
+ *
+ * @param {string}   table            - DB table name, e.g. 'sessions', 'http_events'
+ * @param {string[]} defaultColumns   - from entry.defaultColumns
+ * @param {number}   tzOffsetMs       - server timezone offset in ms
+ * @param {Object}   interfaceNameMap - { interfaceId: 'name [id]' } from config store
+ * @param {Object}   policyNameMap    - { policyId: 'name [id]' } from reports store
+ * @returns {Array} AG-Grid columnDef objects
+ */
+export function buildEventColumnDefs(table, defaultColumns, tzOffsetMs = 0, interfaceNameMap = {}, policyNameMap = {}) {
+  const fields = tableFields[table] || []
+  const visible = new Set(defaultColumns || [])
+
+  // Build timestamp field meta with timezone-aware formatters
+  const timestampMeta = {
+    time_stamp: {
+      width: 160,
+      sort: 'desc',
+      valueFormatter: ({ value }) => formatTimestamp(value, tzOffsetMs),
+    },
+    connect_stamp: { width: 150, valueFormatter: ({ value }) => (value ? formatTimestamp(value, tzOffsetMs) : '') },
+    goodbye_stamp: { width: 150, valueFormatter: ({ value }) => (value ? formatTimestamp(value, tzOffsetMs) : '') },
+    start_time: { width: 150, valueFormatter: ({ value }) => (value ? formatTimestamp(value, tzOffsetMs) : '') },
+    end_time: { width: 150, valueFormatter: ({ value }) => (value ? formatTimestamp(value, tzOffsetMs) : '') },
+  }
+
+  // Dynamic formatters that close over runtime maps — applied after FIELD_META so they take precedence.
+  const dynamicMeta = {
+    // 0 and -1 are treated as unset → 'None'
+    client_intf: {
+      width: 100,
+      valueFormatter: ({ value }) =>
+        !value || value === -1 ? i18n.t('none') : interfaceNameMap[value] ?? String(value),
+    },
+    server_intf: {
+      width: 100,
+      valueFormatter: ({ value }) =>
+        !value || value === -1 ? i18n.t('none') : interfaceNameMap[value] ?? String(value),
+    },
+    interface_id: {
+      width: 100,
+      valueFormatter: ({ value }) =>
+        !value || value === -1 ? i18n.t('none') : interfaceNameMap[value] ?? String(value),
+    },
+    // 0 → 'None', null/not-in-map → '', else mapped name
+    policy_id: {
+      width: 120,
+      valueFormatter: ({ value }) => (value == null || value === 0 ? i18n.t('none') : policyNameMap[value] || ''),
+    },
+  }
+
+  // Table-specific formatters — fields whose meaning differs across tables.
+  // Only injected for the specific table where the converter applies.
+  const tableMeta = {}
+
+  // admin_logins.reason — single-char login reason codes → i18n label
+  // quotas.reason is already human-readable, so this only applies for admin_logins.
+  if (table === 'admin_logins') {
+    tableMeta.reason = {
+      valueFormatter: ({ value }) => (loginReasonMap[value] ? i18n.t(loginReasonMap[value]) : ''),
+    }
+  }
+
+  // quotas.action — 1→'Given', 2→'Exceeded'
+  // wan_failover_action_events.action contains different string values — not converted.
+  if (table === 'quotas') {
+    tableMeta.action = {
+      valueFormatter: ({ value }) => (value == null ? '' : quotaActionMap[value] ?? 'Unknown'),
+    }
+  }
+
+  // directory_connector_login_events.type — I/U/O/A → login/update/logout/authenticate
+  // Other VPN event tables use 'type' with already-readable values — no conversion needed.
+  if (table === 'directory_connector_login_events') {
+    tableMeta.type = {
+      valueFormatter: ({ value }) => (value == null ? '' : directoryConnectorActionMap[value] ?? 'unknown'),
+    }
+  }
+
+  return fields.map(field => {
+    const colDef = {
+      field,
+      headerName: i18n.t(field),
+      hide: !visible.has(field),
+      flex: 1,
+      ...(FIELD_META[field] || {}),
+      ...(dynamicMeta[field] || {}), // runtime-resolved overrides static FIELD_META
+      ...(tableMeta[field] || {}), // table-specific overrides (e.g. reason for admin_logins)
+      ...(timestampMeta[field] || {}), // timestamp formatters always win
+    }
+
+    // AG-Grid ignores `width` when `flex` is also set.
+    // If an explicit width was contributed by any meta layer, drop flex so the
+    // width is actually respected in the grid layout.
+    if (colDef.width) colDef.flex = 0
+
+    return colDef
+  })
+}

--- a/untangle-vue-ui/source/src/util/reportViews.js
+++ b/untangle-vue-ui/source/src/util/reportViews.js
@@ -3,6 +3,32 @@
  * Converts backend report entries into view configs consumed by the display components.
  */
 
+import {
+  buildEventColumnDefs,
+  tableFields,
+  fieldNullDefaults,
+  loginReasonMap,
+  emailActionMap,
+  priorityMap,
+  webFilterReasonMap,
+  webCategoryMap,
+  icmpTypeMap,
+  httpMethodMap,
+  authTypeMap,
+  captivePortalEventMap,
+  quotaActionMap,
+  directoryConnectorActionMap,
+  decodeThreatCategories,
+  formatMemoryMB,
+  formatDiskGB,
+} from './eventTableColumns'
+import i18n from '@/plugins/vue-i18n'
+import { protocolNameMap } from '@/constants'
+
+// ─── Static code→name maps for detail panel formatters ─────────────────────
+// These maps are shared with the column registry — single source of truth.
+// Map values are i18n keys resolved to Title Case display strings at render time.
+
 /**
  * Maps a time-based chart style to the corresponding chart type.
  * Bar variants map to 'column'; area variants to 'areaspline'; line to 'spline'.
@@ -77,6 +103,170 @@ function translateTimeGraphDynamicEntry(entry) {
 }
 
 /**
+ * Builds the config for an event list report.
+ * Column defs are assembled from the column registry based on entry.table and entry.defaultColumns.
+ *
+ * @param {Object} entry            - report entry definition
+ * @param {number} tzOffsetMs       - server timezone offset in ms
+ * @param {Object} interfaceNameMap - { interfaceId: 'name [id]' } — from config store
+ * @param {Object} policyNameMap    - { policyId: 'name [id]' } — from reports store
+ * @param {Object} callbacks        - host-app supplied action callbacks keyed by table/action
+ *   callbacks.onShowDiff(fileName) — called when user clicks 🔍 on a settings_changes row
+ * @returns {Object} report config for GenericEventList
+ */
+function translateEventListEntry(entry, tzOffsetMs, interfaceNameMap = {}, policyNameMap = {}, callbacks = {}) {
+  // Table-specific row actions — only injected when the host app supplies the relevant callback.
+  // 'differences' is a virtual non-SQL action column for row-level diff inspection.
+  const rowActions = []
+  if (entry.table === 'settings_changes' && typeof callbacks.onShowDiff === 'function') {
+    rowActions.push({
+      icon: 'mdi-magnify',
+      tooltip: 'Show difference between previous version',
+      handler: ({ data }) => callbacks.onShowDiff(data.settings_file),
+    })
+  }
+
+  return {
+    key: entry.uniqueId,
+    title: entry.title,
+    category: entry.category, // needed for export filename: "{category}-{title}_date.csv"
+    columns: buildEventColumnDefs(entry.table, entry.defaultColumns, tzOffsetMs, interfaceNameMap, policyNameMap),
+    tzOffsetMs: tzOffsetMs || 0,
+    // Row actions — undefined when empty so UGrid skips the action column setup
+    rowActions: rowActions.length ? rowActions : undefined,
+    // Full ordered field list for this table — used by GenericEventList to iterate ALL
+    // schema fields in the details panel, including those that are SQL NULL in the row
+    // (SQL NULLs are stripped by org.json on the backend so they are absent from the
+    // row object; iterating tableFields instead ensures app groups always appear).
+    tableFields: tableFields[entry.table] || [],
+    // Type-aware null defaults: boolean→false, integer→0.
+    // Used in GenericEventList formatDetailValue so null fields show false/0 not empty.
+    fieldNullDefaults,
+    // Host-app field renderers passed to GenericEventList details panel.
+    // Priority order: custom formatter > built-in byte/timestamp/boolean handlers > String().
+    // Mirrors Map.fields[key].col.renderer logic in PropertyGridController.
+    detailFormatters: {
+      // Protocol number → IANA display name (e.g. 6 → "TCP [6]")
+      protocol: v => protocolNameMap[v] ?? String(v ?? ''),
+
+      // ICMP type number → IANA name; null/unknown → 'Unassigned'
+      icmp_type: v => icmpTypeMap[v] ?? 'Unassigned',
+
+      // HTTP method single-char code → full name
+      method: v => (v == null ? '' : httpMethodMap[v] ?? String(v)),
+
+      // captive_portal auth_type → readable string
+      auth_type: v => (v == null ? '' : authTypeMap[v] ?? 'Unknown'),
+
+      // captive_portal event_info → readable string; null/'' → '', unknown → 'Unknown'
+      event_info: v => (v == null || v === '' ? '' : captivePortalEventMap[v] ?? 'Unknown'),
+
+      // quotas.action — 1→'Given', 2→'Exceeded'; null/'' → '', unknown → 'Unknown'
+      action: v => (v == null || v === '' ? '' : quotaActionMap[v] ?? 'Unknown'),
+
+      // directory_connector_login_events.type — I/U/O/A → login/update/logout/authenticate
+      // Other tables use 'type' with already-readable string values so the map has no effect.
+      type: v => (v == null ? '' : directoryConnectorActionMap[v] ?? String(v)),
+
+      // Interface ID → "name [id]"; 0 and -1 treated as unset → 'None'
+      client_intf: v => (!v || v === -1 ? i18n.t('none') : interfaceNameMap[v] ?? String(v)),
+      server_intf: v => (!v || v === -1 ? i18n.t('none') : interfaceNameMap[v] ?? String(v)),
+      interface_id: v => (!v || v === -1 ? i18n.t('none') : interfaceNameMap[v] ?? String(v)),
+
+      // Policy ID → mapped name; null/0 → 'None'
+      policy_id: v => (v == null || v === 0 ? i18n.t('none') : policyNameMap[v] || ''),
+
+      // admin_logins: local (true=local login, false=remote login)
+      local: v => (v ? 'local' : 'remote'),
+
+      // admin_logins: succeeded (true=success, false=failed)
+      succeeded: v => (v ? 'success' : 'failed'),
+
+      // admin_logins: reason code → i18n Title Case label; unknown codes return ''
+      reason: v => (loginReasonMap[v] ? i18n.t(loginReasonMap[v]) : ''),
+
+      // bandwidth_control_priority 0-7 → i18n Title Case name; 0 falls back to raw integer
+      bandwidth_control_priority: v => (priorityMap[v] ? i18n.t(priorityMap[v]) : String(v ?? '')),
+
+      // bandwidth_control_rule: 0/null → 'None', else raw rule number
+      bandwidth_control_rule: v => (v == null || v === 0 ? i18n.t('none') : String(v)),
+
+      // ad_blocker_action: 'B' → 'Block', else 'Pass'; null/'' → ''
+      ad_blocker_action: v => (v == null || v === '' ? '' : v === 'B' ? i18n.t('block') : i18n.t('pass')),
+
+      // Spam / phish blocker action codes → i18n label + code (e.g. "Pass Message [P]"); null/'' → ''
+      spam_blocker_action: v =>
+        v == null || v === ''
+          ? ''
+          : emailActionMap[v]
+          ? `${i18n.t(emailActionMap[v])} [${v}]`
+          : `${i18n.t('unknown_action')} [${v}]`,
+      spam_blocker_lite_action: v =>
+        v == null || v === ''
+          ? ''
+          : emailActionMap[v]
+          ? `${i18n.t(emailActionMap[v])} [${v}]`
+          : `${i18n.t('unknown_action')} [${v}]`,
+      phish_blocker_action: v =>
+        v == null || v === ''
+          ? ''
+          : emailActionMap[v]
+          ? `${i18n.t(emailActionMap[v])} [${v}]`
+          : `${i18n.t('unknown_action')} [${v}]`,
+
+      // Memory fields — always MB
+      mem_free: v => formatMemoryMB(v),
+      mem_total: v => formatMemoryMB(v),
+      swap_free: v => formatMemoryMB(v),
+      swap_total: v => formatMemoryMB(v),
+
+      // Disk fields — always GB
+      disk_free: v => formatDiskGB(v),
+      disk_total: v => formatDiskGB(v),
+
+      // Web filter reason code → readable label; null/unknown → 'No Rule Applied'
+      web_filter_reason: v => (webFilterReasonMap[v] ? i18n.t(webFilterReasonMap[v]) : i18n.t('no_rule_applied')),
+
+      // web_filter_category_id → category name; null → '', unknown → raw ID string
+      web_filter_category_id: v => (v == null ? '' : webCategoryMap[v] ?? String(v)),
+
+      // Threat prevention reason — same lookup as web_filter_reason; null/unknown → 'No Rule Applied'
+      threat_prevention_reason: v =>
+        webFilterReasonMap[v] ? i18n.t(webFilterReasonMap[v]) : i18n.t('no_rule_applied'),
+
+      // Threat prevention rule ID — 0/null → '' (no rule); else raw ID
+      threat_prevention_rule_id: v => (v == null || v === 0 ? '' : String(v)),
+
+      // Threat prevention category bitmask → comma-separated category names
+      threat_prevention_client_categories: v => decodeThreatCategories(v),
+      threat_prevention_server_categories: v => decodeThreatCategories(v),
+
+      // Threat prevention reputation score — 0/null → '', else raw score
+      threat_prevention_client_reputation: v => (v == null || v === 0 ? '' : String(v)),
+      threat_prevention_server_reputation: v => (v == null || v === 0 ? '' : String(v)),
+
+      // JSON field (alerts) — decode HTML entities encoded by the backend/Jabsorb layer
+      json: v => {
+        if (!v) return ''
+        return String(v)
+          .replace(/&quot;/g, '"')
+          .replace(/&amp;/g, '&')
+          .replace(/&lt;/g, '<')
+          .replace(/&gt;/g, '>')
+          .replace(/&#39;/g, "'")
+      },
+
+      // Settings file path — strip the /usr/share/untangle/settings/ prefix
+      settings_file: v =>
+        String(v ?? '')
+          .replace(/^.*\/settings\//, '')
+          .replace(/^.*\/conf\//, ''),
+    },
+    query: {},
+  }
+}
+
+/**
  * Builds the rendering config for a pie or column-distribution chart report.
  * Maps pie style variants to chart type and donut/slice display options.
  */
@@ -102,10 +292,14 @@ function translatePieGraphEntry(entry) {
  * Selects the correct display component and rendering options at runtime.
  * verticalLayout expands the chart to fill available height instead of a fixed minimum.
  *
- * @param {Object} entry - report entry definition
+ * @param {Object} entry            - report entry definition
+ * @param {number} tzOffsetMs       - server timezone offset in ms
+ * @param {Object} interfaceNameMap - { interfaceId: 'name [id]' } — from config store getter
+ * @param {Object} policyNameMap    - { policyId: 'name [id]' } — from reports store getter
+ * @param {Object} callbacks        - host-app action callbacks (e.g. { onShowDiff })
  * @returns {Object|null} view config, or null if the type is not yet supported
  */
-export function buildReportView(entry) {
+export function buildReportView(entry, tzOffsetMs, interfaceNameMap = {}, policyNameMap = {}, callbacks = {}) {
   if (!entry) return null
   switch (entry.type) {
     case 'TIME_GRAPH':
@@ -130,6 +324,11 @@ export function buildReportView(entry) {
       return {
         component: 'GenericText',
         reports: [translateTextEntry(entry)],
+      }
+    case 'EVENT_LIST':
+      return {
+        component: 'GenericEventList',
+        reports: [translateEventListEntry(entry, tzOffsetMs, interfaceNameMap, policyNameMap, callbacks)],
       }
     default:
       return null

--- a/untangle-vue-ui/source/src/util/reports.js
+++ b/untangle-vue-ui/source/src/util/reports.js
@@ -74,6 +74,27 @@ export function formatReportsForUI(reports) {
 }
 
 /**
+ * Converts a client-side epoch ms to a server-local Date for backend queries.
+ *
+ * The time picker displays times in server timezone. Before sending to the backend
+ * the epoch ms must be adjusted so PostgreSQL (which stores timestamps in server
+ * local time) receives the correct moment to filter on.
+ *
+ * Formula: serverDate = clientDate - browserOffsetMs - serverOffsetMs
+ *   browserOffsetMs = new Date().getTimezoneOffset() * 60000  (positive for UTC- zones)
+ *   serverOffsetMs  = rpc.timeZoneOffset                      (positive for UTC+ zones)
+ *
+ * @param {number|null} dateMs         - epoch ms from the time range picker
+ * @param {number}      serverOffsetMs - server UTC offset in ms (from config/timeZoneOffset)
+ * @returns {Date|null}
+ */
+export function clientToServerDate(dateMs, serverOffsetMs = 0) {
+  if (!dateMs) return null
+  const browserOffsetMs = new Date().getTimezoneOffset() * 60000
+  return new Date(dateMs - browserOffsetMs - serverOffsetMs)
+}
+
+/**
  * Exports report definitions for a category (or all reports) as a downloadable JSON file.
  * Strips UI-computed fields and triggers a client-side Blob download.
  * @param {Array}  allReports   - full reports array from the store

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -2650,9 +2650,9 @@ base@^0.11.1:
     pascalcase "^0.1.1"
 
 baseline-browser-mapping@^2.10.38:
-  version "2.10.38"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz#c84d093c4bf7325c5053c279d90f153c66526042"
-  integrity sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==
+  version "2.10.40"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz#f372c8eb36ff4ad0b5e7ae467014abef124554ba"
+  integrity sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==
 
 batch-processor@1.0.0:
   version "1.0.0"
@@ -2858,9 +2858,9 @@ caniuse-lite@^1.0.30001726:
   integrity sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==
 
 caniuse-lite@^1.0.30001799:
-  version "1.0.30001799"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz#5c909138c27f1a61219d3e092071c1cc7d32dc55"
-  integrity sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==
+  version "1.0.30001800"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz#b896c773e1c39400809415162bb5320371291b36"
+  integrity sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"
@@ -3634,9 +3634,9 @@ electron-to-chromium@^1.5.173:
   integrity sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==
 
 electron-to-chromium@^1.5.376:
-  version "1.5.376"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.376.tgz#16a9d4b72cb16c416aa73a879d92b047b96797ac"
-  integrity sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==
+  version "1.5.382"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.382.tgz#e76f05d3ec337524b9c61761ebbc16fe91ecf5b4"
+  integrity sha512-8ETaWbV6SZOrno+G93Ffd9ENsMtetqdnqj4nlfxFW90Sm5GgnuV28Kf62hqQVD6VUgzm7qFQKsTsAPmeUiU3Ug==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -3822,11 +3822,12 @@ es-shim-unscopables@^1.0.2, es-shim-unscopables@^1.1.0:
     hasown "^2.0.2"
 
 es-to-primitive@^1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.3.1.tgz#abd6ef5b12d7c25bcd9eb3a7ef63e568b451ba4a"
-  integrity sha512-CxN9N56HYfd2m/acc/NOFrZQsN9kU4eh+2kk6A707Kz1krH8tKmfrs5RnftB8WNX80T0NS7vSQsDOlg23diR2g==
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.3.4.tgz#0c854291cf0d7b439d6b9e5771ea837ffaf1f991"
+  integrity sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==
   dependencies:
     es-abstract-get "^1.0.0"
+    es-define-property "^1.0.1"
     es-errors "^1.3.0"
     is-callable "^1.2.7"
     is-date-object "^1.1.0"
@@ -5944,9 +5945,9 @@ no-case@^3.0.4:
     tslib "^2.0.3"
 
 node-exports-info@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/node-exports-info/-/node-exports-info-1.6.0.tgz#1aedafb01a966059c9a5e791a94a94d93f5c2a13"
-  integrity sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/node-exports-info/-/node-exports-info-1.6.2.tgz#243a3105677d6781cd26e6a72350fd928a5cb46f"
+  integrity sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==
   dependencies:
     array.prototype.flatmap "^1.3.3"
     es-errors "^1.3.0"
@@ -5971,9 +5972,9 @@ node-releases@^2.0.19:
   integrity sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==
 
 node-releases@^2.0.48:
-  version "2.0.48"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.48.tgz#4da73d040ada751fc9959d993f27de48792e3b7d"
-  integrity sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==
+  version "2.0.50"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.50.tgz#597197a852071ce42fc2550e58e223242bcba969"
+  integrity sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==
 
 normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -8276,8 +8277,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.62.1"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#08907c3c2b06a4ac20e7090e29ff75e1ab19e810"
+  version "1.62.9"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#ed2aad0cf3d088b640e4e9a4dde650bd93fc9854"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -3511,6 +3511,16 @@ detect-node@^2.0.4:
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
 
+diff-match-patch@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.5.tgz#abb584d5f10cd1196dfc55aa03701592ae3f7b37"
+  integrity sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==
+
+diff@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-5.2.2.tgz#0a4742797281d09cfa699b79ea32d27723623bad"
+  integrity sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -4766,6 +4776,11 @@ highlight.js@^10.7.1:
   version "10.7.3"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-10.7.3.tgz#697272e3991356e40c3cac566a74eef681756531"
   integrity sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==
+
+highlight.js@^11.10.0:
+  version "11.11.1"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.11.1.tgz#fca06fa0e5aeecf6c4d437239135fabc15213585"
+  integrity sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==
 
 hosted-git-info@^2.1.4:
   version "2.8.9"
@@ -8086,6 +8101,16 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+v-code-diff@^1.13.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/v-code-diff/-/v-code-diff-1.13.1.tgz#acead9aeec90ecf0769fdd23dc2e6ca2ecaa631f"
+  integrity sha512-9LTV1dZhC1oYTntyB94vfumGgsfIX5u0fEDSI2Txx4vCE5sI5LkgeLJRRy2SsTVZmDcV+R73sBr0GpPn0TJxMw==
+  dependencies:
+    diff "^5.2.0"
+    diff-match-patch "^1.0.5"
+    highlight.js "^11.10.0"
+    vue-demi "^0.14.6"
+
 v8-compile-cache@^2.0.3:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.4.0.tgz#cdada8bec61e15865f05d097c5f4fd30e94dc128"
@@ -8127,6 +8152,11 @@ vue-cli-plugin-vuetify@^2.4.1:
     null-loader "^4.0.1"
     semver "^7.1.2"
     shelljs "^0.8.3"
+
+vue-demi@^0.14.6:
+  version "0.14.10"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.14.10.tgz#afc78de3d6f9e11bf78c55e8510ee12814522f04"
+  integrity sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==
 
 vue-eslint-parser@^7.10.0:
   version "7.11.0"


### PR DESCRIPTION
Description:

- Event List rendering — Columns show human-readable names for interfaces, policies, protocols, and other coded fields instead of raw IDs/codes
- Export — "Export All Events" button downloads a timestamped CSV via `/admin/download `using the active time range and visible columns
- Settings Diff dialog — Clicking a `settings_changes` row opens a side-by-side diff dialog (green = added, red = removed, yellow = changed)
- Timezone fix — Time range boundaries are converted to server-local time before being sent to the backend
- Stale session recovery — If the reports manager proxy expires, the request retries automatically after re-initialising the session
- Policy names — Policy ID → name map is fetched lazily on first Event List open (no-op if Policy Manager is not installed)

UI for reference 
<img width="1917" height="1056" alt="image" src="https://github.com/user-attachments/assets/036470fd-f650-4ec8-9f67-480de67b4466" />
<img width="1917" height="1056" alt="image" src="https://github.com/user-attachments/assets/26d9682d-9e70-4c62-bbdb-cc1544ea8a47" />
<img width="1910" height="1029" alt="image" src="https://github.com/user-attachments/assets/3bd71dda-52ce-4ab0-8387-3ddc601f79d7" />

