### PR TITLE
ngfw-15642 site lookup tab impl

### DIFF
--- a/untangle-vue-ui/source/src/components/Apps/apps/WebFilter/WebFilter.vue
+++ b/untangle-vue-ui/source/src/components/Apps/apps/WebFilter/WebFilter.vue
@@ -7,6 +7,8 @@
     :metrics-data="formattedMetrics"
     :reports="appReports"
     @toggle-state="toggleAppState"
+    @webfilter-lookup="handleSiteLookup"
+    @webfilter:recategorize="handleRecategorize"
   >
     <template #actions="{ newSettings, isDirty }">
       <div class="d-flex flex-wrap align-center" style="gap: 8px">
@@ -48,10 +50,18 @@
     },
 
     data() {
+      // Prepare the tabs for the WebFilter component, disabling the "site_lookup" tab if the power state is off.
+      const tabs = webFilterAllTabs.map(tab => {
+        if (tab.key === 'site_lookup') {
+          return { ...tab, disabledWhen: () => !this.powerState?.on }
+        }
+        return tab
+      })
+
       return {
         appName: this.appData?.appName || 'web-filter',
         defaultDisplayName: 'Web Filter',
-        webFilterAllTabs,
+        webFilterAllTabs: tabs,
       }
     },
 
@@ -60,6 +70,58 @@
       consolidatedAppData: appInstance => appInstance.buildConsolidatedAppData(),
 
       isExpertMode: ({ $store }) => $store.getters['config/isExpertMode'],
+    },
+
+    methods: {
+      /**
+       * Handles the site lookup operation by invoking the appManager's lookupSite method.
+       * If the appManager is not available, it resolves with an error message.
+       * @param {Object} param0 - The parameters for the site lookup.
+       * @param {string} param0.site - The site to look up.
+       * @param {Function} param0.resolve - The callback to resolve the lookup result.
+       * @returns {void}
+       */
+      handleSiteLookup({ site, resolve }) {
+        if (!this.appManager) {
+          resolve({ error: 'api_wf_lookup_unable_to_perform' })
+          return
+        }
+        this.appManager.lookupSite((res, ex) => {
+          if (ex) {
+            resolve({ error: 'api_wf_lookup_unable_to_perform' })
+            return
+          }
+          const cats = (res?.list || []).map(id => ({ cat: id }))
+          resolve([{ cats }])
+        }, site)
+      },
+
+      /**
+       * Handles the recategorization of a site by invoking the appManager's recategorizeSite method.
+       * If the appManager is not available, it resolves with an error message.
+       * @param {Object} param0 - The parameters for the recategorization.
+       * @param {string} param0.site - The site to recategorize.
+       * @param {string} param0.categoryId - The new category ID for the site.
+       * @param {Function} param0.resolve - The callback to resolve the recategorization result.
+       * @returns {void}
+       */
+      handleRecategorize({ site, categoryId, resolve }) {
+        if (!this.appManager) {
+          resolve({ error: 'unable_to_submit_suggestion' })
+          return
+        }
+        this.appManager.recategorizeSite(
+          (res, ex) => {
+            if (ex) {
+              resolve({ error: 'unable_to_submit_suggestion' })
+              return
+            }
+            resolve({ categoryId: res })
+          },
+          site,
+          categoryId,
+        )
+      },
     },
   }
 </script>

--- a/untangle-vue-ui/source/src/components/Apps/apps/WebFilter/capabilities.js
+++ b/untangle-vue-ui/source/src/components/Apps/apps/WebFilter/capabilities.js
@@ -86,4 +86,7 @@ export const ngfwCapabilities = {
       enabled: true,
     },
   },
+  siteLookup: {
+    recategorize: { render: true },
+  },
 }

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -3634,9 +3634,9 @@ electron-to-chromium@^1.5.173:
   integrity sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==
 
 electron-to-chromium@^1.5.376:
-  version "1.5.382"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.382.tgz#e76f05d3ec337524b9c61761ebbc16fe91ecf5b4"
-  integrity sha512-8ETaWbV6SZOrno+G93Ffd9ENsMtetqdnqj4nlfxFW90Sm5GgnuV28Kf62hqQVD6VUgzm7qFQKsTsAPmeUiU3Ug==
+  version "1.5.384"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.384.tgz#78f8a72abe693d6c229481866b51eef609bb0f2e"
+  integrity sha512-g6KAKY1vkYsADvSPWvdJsuYT0ixdcu6lUtD9P/wJKGBEDlZVXh2AX42j1mPqqaQPDluWjara9ziQ7xqAeXCt5A==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -8277,8 +8277,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.62.9"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#ed2aad0cf3d088b640e4e9a4dde650bd93fc9854"
+  version "1.62.13"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#23494001d230498ab22246a52123882a8e9adaa2"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
## Summary

Wire up the NGFW host-side event handlers for the WebFilter Site Lookup tab — `lookupSite` and `recategorizeSite` RPC calls — and enable the recategorize capability. Also override the Site Lookup tab's disable condition to use app power state instead of the settings toggle.

## Motivation

NGFW-15642: The shared WebFilter component (vuntangle) now has a fully implemented Site Lookup tab with recategorize support. The NGFW host needs to handle the emitted events by making the actual RPC calls to the backend and transforming the responses to the shared component's expected format.

## Changes

### WebFilter Host (`WebFilter.vue`)
- `handleSiteLookup` — handles `@webfilter-lookup` event, calls `appManager.lookupSite`, transforms NGFW response `{ list: [id, ...] }` to shared format `[{ cats: [{ cat: id }] }]`
- `handleRecategorize` — handles `@webfilter:recategorize` event, calls `appManager.recategorizeSite`, returns `{ categoryId }` on success or `{ error }` on failure
- RPC callbacks follow the established `(res, ex)` pattern (consistent with VirusBlocker, PhishBlocker, SpamBlocker)
- Override `disabledWhen` on the `site_lookup` tab to check `powerState.on` — the default checks `settings.enabled` which doesn't reflect NGFW's app ON/OFF state

### NGFW Capabilities (`capabilities.js`)
- Added `siteLookup: { recategorize: { render: true } }` — enables the recategorize suggestion form (defaults to hidden in the shared component)

## Testing

1. **Lookup**: Open WebFilter → Site Lookup tab → enter a domain → click Lookup → verify categories appear with correct BLOCKED/FLAGGED chips
2. **Recategorize**: After lookup → check "Suggest a different category" → select a category → click Suggest → verify "Suggestion Submitted" dialog → click OK → verify reset
3. **Lookup failure**: Stop the WebFilter app or simulate backend error → attempt lookup → verify error alert
4. **Recategorize failure**: Simulate backend error → attempt suggest → verify "Alert" dialog with failure message
5. **Tab disable**: Turn off WebFilter via Status tab → verify Site Lookup tab disables immediately (no save required, driven by power state)

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
