### PR TITLE
NGFW-15805 feature implementation changes

### DIFF
--- a/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
+++ b/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
@@ -5,10 +5,12 @@
       :view-override="selectedReportView"
       :categories="categoriesForNav"
       :show-report-selector="true"
+      :show-auto-refresh="true"
       :is-local-ui="false"
       @fetch-data="onFetchData"
       @view-report="onViewReport"
       @export-all-events="onExportAllEvents"
+      @auto-refresh-change="onAutoRefreshChange"
     />
 
     <!-- Settings diff dialog — opened by the  action column on settings_changes rows -->
@@ -37,6 +39,8 @@
         $dateTimeRangeComponent: 'date-time-range-presets',
         $serverTimezoneOffsetMs: () => this.timeZoneOffset,
         $serverClockOffsetMs: () => this.serverClockOffsetMs,
+        $refreshTick: () => this.refreshTick,
+        $showTimeRangeHistory: true,
       }
     },
 
@@ -51,6 +55,11 @@
         lastEndMs: null,
         // Last-used extra conditions (non-time) — forwarded to server export
         lastConditions: [],
+
+        // Auto-refresh state
+        autoRefresh: false,
+        refreshTick: 0,
+        refreshTimer: null,
       }
     },
 
@@ -82,6 +91,10 @@
       },
     },
 
+    beforeDestroy() {
+      clearTimeout(this.refreshTimer)
+    },
+
     /**
      * Fetch policy info once when the component mounts.
      * The action is a no-op if already loaded or if policy-manager is not installed.
@@ -91,6 +104,26 @@
     },
 
     methods: {
+      onAutoRefreshChange(val) {
+        this.autoRefresh = val
+        if (val) {
+          this.refreshTick++
+        } else {
+          clearTimeout(this.refreshTimer)
+          this.refreshTimer = null
+        }
+      },
+
+      scheduleRefresh() {
+        clearTimeout(this.refreshTimer)
+        this.refreshTimer = null
+        if (this.autoRefresh) {
+          this.refreshTimer = setTimeout(() => {
+            this.refreshTick++
+          }, 5000)
+        }
+      },
+
       /**
        * Handles data fetch requests from the report display component.
        * Converts the raw epoch ms from the time picker to server-local dates before
@@ -171,6 +204,8 @@
         } catch (err) {
           Util.handleException(err)
           resolve(null)
+        } finally {
+          this.scheduleRefresh()
         }
       },
 

--- a/untangle-vue-ui/source/src/components/reports/Reports.vue
+++ b/untangle-vue-ui/source/src/components/reports/Reports.vue
@@ -29,6 +29,7 @@
           showViewMore: true,
           maximizableCards: true,
           exportable: true,
+          enableSearch: true,
         },
       }
     },

--- a/untangle-vue-ui/source/src/store/reports.js
+++ b/untangle-vue-ui/source/src/store/reports.js
@@ -251,7 +251,12 @@ const actions = {
 
       // Re-initialise the reports manager and retry the request
       await dispatch('loadReports')
-      result = await callRpc(state.reportsManager)
+      try {
+        result = await callRpc(state.reportsManager)
+      } catch (retryError) {
+        Util.handleException(retryError)
+        return { list: [] }
+      }
     }
 
     if (!result) return { list: [] }

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -2650,9 +2650,9 @@ base@^0.11.1:
     pascalcase "^0.1.1"
 
 baseline-browser-mapping@^2.10.38:
-  version "2.10.40"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz#f372c8eb36ff4ad0b5e7ae467014abef124554ba"
-  integrity sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==
+  version "2.10.42"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz#195dcc76baa269a497f0b07decace169fee9ac58"
+  integrity sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==
 
 batch-processor@1.0.0:
   version "1.0.0"
@@ -2858,9 +2858,9 @@ caniuse-lite@^1.0.30001726:
   integrity sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==
 
 caniuse-lite@^1.0.30001799:
-  version "1.0.30001800"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz#b896c773e1c39400809415162bb5320371291b36"
-  integrity sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==
+  version "1.0.30001802"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001802.tgz#2671fb13d468930586c56ffa80feb1c51e18ec69"
+  integrity sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"
@@ -3634,9 +3634,9 @@ electron-to-chromium@^1.5.173:
   integrity sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==
 
 electron-to-chromium@^1.5.376:
-  version "1.5.384"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.384.tgz#78f8a72abe693d6c229481866b51eef609bb0f2e"
-  integrity sha512-g6KAKY1vkYsADvSPWvdJsuYT0ixdcu6lUtD9P/wJKGBEDlZVXh2AX42j1mPqqaQPDluWjara9ziQ7xqAeXCt5A==
+  version "1.5.387"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz#d3ce821b0a37af5a46e2d2a33379ecfa16303636"
+  integrity sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -3875,9 +3875,9 @@ eslint-import-resolver-node@^0.3.9:
     resolve "^2.0.0-next.6"
 
 eslint-module-utils@^2.12.1:
-  version "2.13.0"
-  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz#882beaf64927567358816bf4dc0f050fd52e0fb9"
-  integrity sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz#611f8e1c6ceb29a93eb949e1cc670b8287764819"
+  integrity sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==
   dependencies:
     debug "^3.2.7"
 
@@ -8277,8 +8277,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.62.13"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#23494001d230498ab22246a52123882a8e9adaa2"
+  version "1.62.15"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#a291d59cdbae54e1aa2570e17007cf1b5069fba2"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
- Added **auto-refresh** support to Report Details — toggleable via toolbar, polls every 5 seconds after each data fetch completes, with proper cleanup on destroy
- Enabled **search** functionality on the Reports grid view
- Enabled **time range** history display in report details
- Added **error handling** for the retry path in the reports store (`loadReportData`) — catches failures on the second RPC attempt and returns an empty list instead of throwing