### PR TITLE
ngfw-15643 Web Filter Rules Tab Impl

### DIFF
--- a/untangle-vue-ui/source/src/components/Apps/apps/CaptivePortal/CaptivePortal.vue
+++ b/untangle-vue-ui/source/src/components/Apps/apps/CaptivePortal/CaptivePortal.vue
@@ -45,6 +45,7 @@
           interfaces: this.interfaces,
           directoryGroups: this.directoryGroups,
           directoryDomains: this.directoryDomains,
+          directoryUsers: this.directoryUsers,
         }),
         $features: { isExpertMode: this.isExpertMode },
         $readOnly: false,

--- a/untangle-vue-ui/source/src/components/Apps/apps/WebFilter/WebFilter.vue
+++ b/untangle-vue-ui/source/src/components/Apps/apps/WebFilter/WebFilter.vue
@@ -27,26 +27,34 @@
   import { WebFilter, UAppStatusRemove, webFilterAllTabs } from 'vuntangle'
   import { VDivider } from 'vuetify/lib'
   import appMixin from '../appMixin'
+  import conditionDataMixin from '../conditionDataMixin'
   import { ngfwCapabilities } from './capabilities'
+  import util from '@/util/util'
 
   export default {
     name: 'WebFilterApp',
 
     components: { WebFilter, UAppStatusRemove, VDivider },
 
-    mixins: [appMixin],
+    mixins: [appMixin, conditionDataMixin(['directory-connector'])],
 
     provide() {
       return {
         capabilities: ngfwCapabilities,
-        $features: { isExpertMode: this.isExpertMode },
+        $remoteData: () => ({
+          interfaces: this.interfaces,
+          directoryGroups: this.directoryGroups,
+          directoryDomains: this.directoryDomains,
+          directoryUsers: this.directoryUsers,
+        }),
+        $features: { isExpertMode: this.isExpertMode, hasFlaggedAction: true },
         $readOnly: false,
         $applications: {},
       }
     },
 
     props: {
-      appData: { type: Object, default: null },
+      appData: { type: Object, default: null }, // The application data for the Web Filter app
     },
 
     data() {
@@ -66,10 +74,26 @@
     },
 
     computed: {
-      // Transforms appData into the format expected by WebFilter and its child components.
+      // Consolidated app data to pass to the WebFilter component.
       consolidatedAppData: appInstance => appInstance.buildConsolidatedAppData(),
 
+      // Returns if the user is in expert mode from the store
       isExpertMode: ({ $store }) => $store.getters['config/isExpertMode'],
+
+      // Returns the network settings from the store
+      networkSettings: ({ $store }) => $store.getters['config/networkSetting'],
+
+      // Returns the interfaces for condition value from network settings
+      interfaces: ({ networkSettings }) => {
+        return util.getInterfaceList(networkSettings, true, true)
+      },
+    },
+
+    /**
+     * Fetches the network settings when the component is created.
+     */
+    created() {
+      this.$store.dispatch('config/getNetworkSettings', false)
     },
 
     methods: {

--- a/untangle-vue-ui/source/src/components/Apps/apps/appMixin.js
+++ b/untangle-vue-ui/source/src/components/Apps/apps/appMixin.js
@@ -181,6 +181,8 @@ export default {
           // TODO Remove this once all apps are migrated to Vue UI and Parent Layout is changed
           this.sendEventToParentWindow(EVENT_ACTIONS.REFRESH_APP_STATUS)
         }
+      } catch (error) {
+        Util.handleException(error)
       } finally {
         this.toggling = false
       }

--- a/untangle-vue-ui/source/src/components/Apps/apps/conditionDataMixin.js
+++ b/untangle-vue-ui/source/src/components/Apps/apps/conditionDataMixin.js
@@ -1,3 +1,5 @@
+import { usernameOptions, directoryConnectorGroupOptions, directoryConnectorDomainOptions } from 'vuntangle'
+
 /**
  * Factory mixin for app components that need runtime condition dropdown data.
  *
@@ -8,7 +10,7 @@
  *   mixins: [appMixin, conditionDataMixin(['directory-connector'])]
  *
  *   Then include the needed keys in provide() → $remoteData:
- *   $remoteData: () => ({ ..., directoryGroups: this.directoryGroups, directoryDomains: this.directoryDomains })
+ *   $remoteData: () => ({ ..., directoryGroups: this.directoryGroups, directoryDomains: this.directoryDomains, directoryUsers: this.directoryUsers })
  */
 export default function conditionDataMixin(appNames = []) {
   return {
@@ -16,12 +18,14 @@ export default function conditionDataMixin(appNames = []) {
       conditionData: ({ $store }) => $store.getters['apps/conditionData'],
       directoryGroups: ({ conditionData }) =>
         conditionData?.directoryGroups?.length
-          ? [{ text: 'Any Group', value: '*' }, ...conditionData.directoryGroups]
+          ? [...directoryConnectorGroupOptions, ...conditionData.directoryGroups]
           : [],
       directoryDomains: ({ conditionData }) =>
         conditionData?.directoryDomains?.length
-          ? [{ text: 'Any Domain', value: '*' }, ...conditionData.directoryDomains]
+          ? [...directoryConnectorDomainOptions, ...conditionData.directoryDomains]
           : [],
+      directoryUsers: ({ conditionData }) =>
+        conditionData?.directoryUsers?.length ? [...usernameOptions, ...conditionData.directoryUsers] : [],
     },
     created() {
       this.$store.dispatch('apps/fetchConditionData', appNames)

--- a/untangle-vue-ui/source/src/components/settings/services/PolicyManager.vue
+++ b/untangle-vue-ui/source/src/components/settings/services/PolicyManager.vue
@@ -46,6 +46,7 @@
   import { PolicyManager, NoLicense, UAppStatusRemove, UAppInstall, UBtn } from 'vuntangle'
   import { VDivider } from 'vuetify/lib'
   import util from '../../../util/util'
+  import conditionDataMixin from '../../Apps/apps/conditionDataMixin'
   import serviceMixin from './serviceMixin'
 
   export default {
@@ -57,13 +58,16 @@
       UBtn,
       VDivider,
     },
-    mixins: [serviceMixin],
+    mixins: [serviceMixin, conditionDataMixin(['directory-connector'])],
 
     provide() {
       return {
         $remoteData: () => ({
           interfaces: this.interfaces,
           policies: this.settings?.policies,
+          directoryGroups: this.directoryGroups,
+          directoryDomains: this.directoryDomains,
+          directoryUsers: this.directoryUsers,
         }),
         $features: {
           hasIpv6Support: false,

--- a/untangle-vue-ui/source/src/store/apps.js
+++ b/untangle-vue-ui/source/src/store/apps.js
@@ -66,13 +66,14 @@ const CONDITION_DATA_FETCHERS = {
     const app = await dispatch('getApp', { appName: 'directory-connector' })
     if (!app) {
       // Clear any stale data left from a previous installation so static fallback options are shown
-      commit('SET_CONDITION_DATA', { directoryGroups: [], directoryDomains: [] })
+      commit('SET_CONDITION_DATA', { directoryGroups: [], directoryDomains: [], directoryUsers: [] })
       return
     }
 
-    const [groupResult, domainResult] = await Promise.all([
+    const [groupResult, domainResult, userResult] = await Promise.all([
       new Promise(resolve => app.getRuleConditionalGroupEntriesV2((r, ex) => resolve(ex ? null : r))),
       new Promise(resolve => app.getRuleConditionalDomainEntriesV2((r, ex) => resolve(ex ? null : r))),
+      new Promise(resolve => app.getRuleConditionalUserEntriesV2((r, ex) => resolve(ex ? null : r))),
     ])
 
     commit('SET_CONDITION_DATA', {
@@ -81,6 +82,10 @@ const CONDITION_DATA_FETCHERS = {
         value: g.SAMAccountName,
       })),
       directoryDomains: (domainResult || []).map(d => ({ text: d, value: d })),
+      directoryUsers: (userResult || []).map(u => ({
+        text: [u.firstName, u.lastName].filter(Boolean).join(' ') || u.uid,
+        value: u.uid,
+      })),
     })
   },
 }

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -2649,7 +2649,7 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-baseline-browser-mapping@^2.10.38:
+baseline-browser-mapping@^2.10.42:
   version "2.10.42"
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz#195dcc76baa269a497f0b07decace169fee9ac58"
   integrity sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==
@@ -2745,14 +2745,14 @@ browserslist@^4.0.0, browserslist@^4.16.3, browserslist@^4.21.4, browserslist@^4
     update-browserslist-db "^1.1.3"
 
 browserslist@^4.24.0:
-  version "4.28.4"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.4.tgz#dd8b8167a32845ff5f8cd6ce13f5abba16cd04c9"
-  integrity sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==
+  version "4.28.5"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.5.tgz#438b7d38c0d4b47740bbb36778d5bdca01b37838"
+  integrity sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==
   dependencies:
-    baseline-browser-mapping "^2.10.38"
-    caniuse-lite "^1.0.30001799"
-    electron-to-chromium "^1.5.376"
-    node-releases "^2.0.48"
+    baseline-browser-mapping "^2.10.42"
+    caniuse-lite "^1.0.30001800"
+    electron-to-chromium "^1.5.387"
+    node-releases "^2.0.50"
     update-browserslist-db "^1.2.3"
 
 buffer-from@^1.0.0:
@@ -2857,10 +2857,10 @@ caniuse-lite@^1.0.30001726:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001734.tgz#f97e08599e2d75664543ae4b6ef25dc2183c5cc6"
   integrity sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==
 
-caniuse-lite@^1.0.30001799:
-  version "1.0.30001802"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001802.tgz#2671fb13d468930586c56ffa80feb1c51e18ec69"
-  integrity sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw==
+caniuse-lite@^1.0.30001800:
+  version "1.0.30001803"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz#b2a5d696e042bc8304dcd4942c39fe330fbbcb24"
+  integrity sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==
 
 case-sensitive-paths-webpack-plugin@^2.3.0:
   version "2.4.0"
@@ -3633,10 +3633,10 @@ electron-to-chromium@^1.5.173:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.200.tgz#adffa5db97390ce9d48987f528117a608ed0d7c9"
   integrity sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==
 
-electron-to-chromium@^1.5.376:
-  version "1.5.387"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.387.tgz#d3ce821b0a37af5a46e2d2a33379ecfa16303636"
-  integrity sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ==
+electron-to-chromium@^1.5.387:
+  version "1.5.388"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.388.tgz#002666dfda32e087c44fd01b7ce1719b6ec89c57"
+  integrity sha512-Pl/aJaqOOxYxda3vcx1IKSJimwYXHDkEnGn0F+kG2EE68dDtx2uCinaS+Vih8Z91B9t8CSAbiF/HKyWcnXjhzw==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -5971,7 +5971,7 @@ node-releases@^2.0.19:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.21.tgz#f59b018bc0048044be2d4c4c04e4c8b18160894c"
   integrity sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==
 
-node-releases@^2.0.48:
+node-releases@^2.0.50:
   version "2.0.50"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.50.tgz#597197a852071ce42fc2550e58e223242bcba969"
   integrity sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==
@@ -8277,8 +8277,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.62.15"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#a291d59cdbae54e1aa2570e17007cf1b5069fba2"
+  version "1.62.17"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#944cc0374698831d9334bf681e857ca53397105f"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
## Summary

Implement the Web Filter Rules tab in the NGFW Vue UI, wiring up the NGFW host wrapper (`WebFilter.vue`) with `conditionDataMixin`, `$remoteData`, and `hasFlaggedAction` feature flag to support the shared rules infrastructure. Also fetches Directory Connector user entries from the backend to populate the USERNAME condition dropdown across all rule-enabled apps.

## Motivation

The Web Filter Rules tab migration (NGFW-15643) requires the NGFW host wrapper to provide condition data (`$remoteData`) so the shared `RulesList`/`RulesGrid`/`RuleDialog` components can render condition value dropdowns (interfaces, directory groups, domains, usernames). The USERNAME condition was previously limited to 3 static sentinel values — this brings parity with the ExtJS behavior by fetching actual AD users via Directory Connector.

## Changes

### Web Filter Host Wrapper (`WebFilter.vue`)
- Added `conditionDataMixin(['directory-connector'])` to mixins
- Added `$remoteData` provider with `interfaces`, `directoryGroups`, `directoryDomains`, `directoryUsers`
- Added `hasFlaggedAction: true` to `$features` for the flagged checkbox in shared rule components
- Added `networkSettings` and `interfaces` computed properties, `created()` hook to fetch network settings

### Directory Connector User Entries (cross-app enhancement)
- **`store/apps.js`**: Extended DC fetcher to call `getRuleConditionalUserEntriesV2`, maps `UserEntry` to `{ text, value }` using `firstName`/`lastName` and `uid`
- **`conditionDataMixin.js`**: Added `directoryUsers` computed (prepends `usernameOptions` sentinels before DC users); replaced hardcoded sentinel values for groups/domains with imported `directoryConnectorGroupOptions`/`directoryConnectorDomainOptions` from vuntangle
- **`CaptivePortal.vue`**: Added `directoryUsers` to `$remoteData`
- **`PolicyManager.vue`**: Added `conditionDataMixin(['directory-connector'])`, extended `$remoteData` with `directoryGroups`, `directoryDomains`, `directoryUsers`

### Bug Fix (`appMixin.js`)
- Added missing `catch` block in `toggleAppState` to handle exceptions via `Util.handleException`

## Testing

1. Open **Web Filter** → Rules tab → add a rule → verify condition dropdowns populate correctly (interfaces, directory groups/domains, usernames)
2. Add a USERNAME condition → verify DC users appear in the combobox alongside the 3 sentinel values (`[any]`, `[authenticated]`, `[unauthenticated]`)
3. Toggle the **Flagged** checkbox in the rule action section → verify it persists after save
4. Open **Captive Portal** → Capture Rules → add USERNAME condition → verify DC users populate
5. Open **Policy Manager** → Policy Rules → add USERNAME/DIRECTORY_CONNECTOR_GROUP/DOMAIN conditions → verify population
6. With Directory Connector **not installed**: verify USERNAME shows only static sentinels with free-text input

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
