### PR TITLE
ngfw-15649 updated WebFilter.vue for advanced tab impl

### DIFF
--- a/untangle-vue-ui/source/src/components/Apps/apps/WebFilter/WebFilter.vue
+++ b/untangle-vue-ui/source/src/components/Apps/apps/WebFilter/WebFilter.vue
@@ -9,15 +9,16 @@
     @toggle-state="toggleAppState"
     @webfilter-lookup="handleSiteLookup"
     @webfilter:recategorize="handleRecategorize"
+    @webfilter:clear-cache="handleClearCache"
   >
-    <template #actions="{ newSettings, isDirty }">
+    <template #actions="{ newSettings, isDirty, validate }">
       <div class="d-flex flex-wrap align-center" style="gap: 8px">
         <div style="min-width: 140px">
           <u-app-status-remove class="mt-0" :app-name="appDisplayName" @remove="removeApp" />
         </div>
         <v-divider vertical class="mx-4" />
         <u-btn class="mr-2" @click="refreshData">{{ $t('refresh') }}</u-btn>
-        <u-btn :disabled="!isDirty || saveDisabled" @click="saveSettings(newSettings)">{{ $t('save') }}</u-btn>
+        <u-btn :disabled="!isDirty || saveDisabled" @click="onSave(newSettings, validate)">{{ $t('save') }}</u-btn>
       </div>
     </template>
   </web-filter>
@@ -98,6 +99,21 @@
 
     methods: {
       /**
+       * Handles the save operation for the Web Filter settings.
+       * Validates the new settings and saves them if valid.
+       *
+       * @param {Object} newSettings - The new settings to be saved.
+       * @param {Function} validate - The validation function to check the settings.
+       * @returns {Promise<void>}
+       */
+      async onSave(newSettings, validate) {
+        const isValid = await validate()
+        console.log('onSave: isValid', isValid, 'newSettings', newSettings)
+        if (!isValid) return
+        this.saveSettings(newSettings)
+      },
+
+      /**
        * Handles the site lookup operation by invoking the appManager's lookupSite method.
        * If the appManager is not available, it resolves with an error message.
        * @param {Object} param0 - The parameters for the site lookup.
@@ -145,6 +161,29 @@
           site,
           categoryId,
         )
+      },
+
+      /**
+       * Handles the category url cache clear by invoking the appManager's clearCache method.
+       * If the appManager is not available, it resolves with an error message.
+       * @param {Object} param0 - The parameters for the recategorization.
+       * @param {Function} param0.resolve - The callback to resolve the recategorization result.
+       * @returns {void}
+       */
+      handleClearCache({ resolve }) {
+        if (!this.appManager) {
+          resolve({ error: 'unable_to_clear_cache' })
+          return
+        }
+        this.$store.commit('SET_LOADER', true)
+        this.appManager.clearCache((_res, ex) => {
+          this.$store.commit('SET_LOADER', false)
+          if (ex) {
+            resolve({ error: ex.message || 'unable_to_clear_cache' })
+            return
+          }
+          resolve({ success: true })
+        })
       },
     },
   }

--- a/untangle-vue-ui/source/src/components/Apps/apps/WebFilter/capabilities.js
+++ b/untangle-vue-ui/source/src/components/Apps/apps/WebFilter/capabilities.js
@@ -87,6 +87,10 @@ export const ngfwCapabilities = {
     },
   },
   siteLookup: {
+    ...webFilterDefaultCapabilities.siteLookup,
     recategorize: { render: true },
+  },
+  advanced: {
+    ...webFilterDefaultCapabilities.advanced,
   },
 }

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -2720,9 +2720,9 @@ boolbase@^1.0.0:
   integrity sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==
 
 brace-expansion@^1.1.7:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
-  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
+  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -3634,9 +3634,9 @@ electron-to-chromium@^1.5.173:
   integrity sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==
 
 electron-to-chromium@^1.5.387:
-  version "1.5.388"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.388.tgz#002666dfda32e087c44fd01b7ce1719b6ec89c57"
-  integrity sha512-Pl/aJaqOOxYxda3vcx1IKSJimwYXHDkEnGn0F+kG2EE68dDtx2uCinaS+Vih8Z91B9t8CSAbiF/HKyWcnXjhzw==
+  version "1.5.389"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz#538be9ebec78026d4daba6be321ab854dfac2a8f"
+  integrity sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -5972,9 +5972,9 @@ node-releases@^2.0.19:
   integrity sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==
 
 node-releases@^2.0.50:
-  version "2.0.50"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.50.tgz#597197a852071ce42fc2550e58e223242bcba969"
-  integrity sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==
+  version "2.0.51"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.51.tgz#cdc08433577f5b32ad01694481726e22eeb54aef"
+  integrity sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==
 
 normalize-package-data@^2.5.0:
   version "2.5.0"
@@ -8277,8 +8277,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.62.17"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#944cc0374698831d9334bf681e857ca53397105f"
+  version "1.62.18"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#0041ee354c0ffa7183489406d19051842bc407db"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
## Summary

NGFW host-side changes for the WebFilter Advanced tab migration: adds `@webfilter:clear-cache` event handling, save-time validation gating via `onSave`, and the `advanced` capability override in `ngfwCapabilities`.

## Motivation

Companion to the vuntangle PR that implements the shared `AdvancedTab.vue` component. The NGFW host needs to handle the new `webfilter:clear-cache` event (RPC call to `appManager.clearCache`), wire up save-time validation, and declare the `advanced` capability section.

## Changes

### WebFilter.vue (NGFW host)
- Added `@webfilter:clear-cache="handleClearCache"` event binding
- `handleClearCache({ resolve })` — calls `appManager.clearCache` RPC with `SET_LOADER` start/stop and `{ resolve }` callback pattern (consistent with `handleSiteLookup` and `handleRecategorize`)
- Destructured `validate` from `#actions` slot
- Added `onSave(newSettings, validate)` — awaits `validateTabs()` before calling `saveSettings`, blocking save on invalid fields (same pattern as CaptivePortal)

### capabilities.js (NGFW override)
- Added `advanced` section spreading `webFilterDefaultCapabilities.advanced` (all render flags default `true`)
- Added `...webFilterDefaultCapabilities.siteLookup` spread to `siteLookup` section for consistency

## Testing

1. Navigate to WebFilter → Advanced tab
2. Enter an invalid Google Apps domain (e.g. `http://example.com`) → click Save → verify save is blocked and tab shows red alert icon
3. Fix the domain → click Save → verify settings save successfully
4. Click "Clear Category URL Cache" → verify loader appears, then success toast
5. Verify other tabs (Status, Categories, Rules, etc.) still save correctly
6. Verify Refresh button still works

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
