### PR TITLE
NGFW-15849 Date and Time range preset value store changes

### DIFF
--- a/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
+++ b/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
@@ -45,6 +45,7 @@
         $serverClockOffsetMs: () => this.serverClockOffsetMs,
         $refreshTick: () => this.refreshTick,
         $showTimeRangeHistory: true,
+        $timeRangeSessionKey: () => this.$store.getters['reports/timeRangeSessionKey'],
       }
     },
 

--- a/untangle-vue-ui/source/src/store/reports.js
+++ b/untangle-vue-ui/source/src/store/reports.js
@@ -40,6 +40,9 @@ const getDefaultState = () => ({
   // Global conditions applied across all reports — persists across route navigation
   // Each condition: { column, operator, value, autoFormatValue }
   globalConditions: [],
+
+  // Unique key per login session — used by DateTimeRangePresets to reset saved state on logout/login
+  timeRangeSessionKey: null,
 })
 
 const getters = {
@@ -88,6 +91,7 @@ const getters = {
    * Returns an empty map when no policy-manager is installed.
    */
   globalConditions: state => state.globalConditions,
+  timeRangeSessionKey: state => state.timeRangeSessionKey,
 
   policyNameMap: state => {
     const map = {}
@@ -159,6 +163,10 @@ const mutations = {
     state.globalConditions = []
   },
 
+  SET_TIME_RANGE_SESSION_KEY(state, key) {
+    state.timeRangeSessionKey = key
+  },
+
   RESET(state) {
     Object.assign(state, getDefaultState())
   },
@@ -169,7 +177,7 @@ const actions = {
    * Load all reports from backend
    * Called once at application boot via router guard
    */
-  async loadReports({ commit }) {
+  async loadReports({ commit, state }) {
     commit('SET_LOADING', true)
     commit('SET_ERROR', null)
 
@@ -203,6 +211,9 @@ const actions = {
       }
 
       commit('SET_LAST_LOADED', Date.now())
+      if (!state.timeRangeSessionKey) {
+        commit('SET_TIME_RANGE_SESSION_KEY', Date.now())
+      }
       commit('SET_LOADING', false)
 
       return { success: true }

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -3634,9 +3634,9 @@ electron-to-chromium@^1.5.173:
   integrity sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==
 
 electron-to-chromium@^1.5.389:
-  version "1.5.392"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz#31e9f9af0d8df3d1489468a4242b173605617482"
-  integrity sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==
+  version "1.5.393"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz#aec971df2a6f4f7e51fbacb200d66cebfc7d3c17"
+  integrity sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -8277,8 +8277,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.62.27"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#a7a93a2606613a085030eba741671cbcd1edc4c7"
+  version "1.62.29"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#9926c3913aadcfe3525c38e83d6a5c993432019a"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
Add a `timeRangeSessionKey` to the reports Vuex store that generates a unique key per login session
Pass `$timeRangeSessionKey` to the `ReportDetails` component so `DateTimeRangePresets` can use it to reset saved state on logout/login
The session key is initialized once during `loadReports` and cleared on store reset (logout)
Why
Previously, `DateTimeRangePresets` could retain stale saved state across logout/login cycles. This fix ensures the preset values are scoped to each login session by providing a session-aware key that changes when the user logs back in.