### PR TITLE
ngfw-15901 firewall status tab impl

### DIFF
--- a/untangle-vue-ui/source/src/components/Apps/apps/Firewall/Firewall.vue
+++ b/untangle-vue-ui/source/src/components/Apps/apps/Firewall/Firewall.vue
@@ -1,0 +1,54 @@
+<template>
+  <firewall
+    :settings="settings"
+    :app-data="consolidatedAppData"
+    :metrics-data="formattedMetrics"
+    :reports="appReports"
+    @toggle-state="toggleAppState"
+  >
+    <!-- Custom action buttons slot -->
+    <template #actions="{ newSettings, isDirty }">
+      <div class="d-flex flex-wrap align-center" style="gap: 8px">
+        <div style="min-width: 140px">
+          <u-app-status-remove class="mt-0" :app-name="appDisplayName" @remove="removeApp" />
+        </div>
+        <v-divider vertical class="mx-4" />
+        <u-btn class="mr-2" @click="refreshData">{{ $t('refresh') }}</u-btn>
+        <u-btn :disabled="!isDirty || saveDisabled" @click="saveSettings(newSettings)">{{ $t('save') }}</u-btn>
+      </div>
+    </template>
+  </firewall>
+</template>
+
+<script>
+  import { Firewall, UAppStatusRemove } from 'vuntangle'
+  import { VDivider } from 'vuetify/lib'
+  import appMixin from '../appMixin'
+
+  export default {
+    name: 'FirewallApp',
+
+    components: {
+      Firewall,
+      UAppStatusRemove,
+      VDivider,
+    },
+
+    mixins: [appMixin],
+
+    props: {
+      appData: { type: Object, default: null },
+    },
+
+    data() {
+      return {
+        appName: this.appData?.appName || 'firewall',
+        defaultDisplayName: 'Firewall',
+      }
+    },
+
+    computed: {
+      consolidatedAppData: appInstance => appInstance.buildConsolidatedAppData(),
+    },
+  }
+</script>

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -1153,9 +1153,9 @@
     strip-json-comments "^3.1.1"
 
 "@fontsource/metropolis@^5.2.5":
-  version "5.2.5"
-  resolved "https://registry.yarnpkg.com/@fontsource/metropolis/-/metropolis-5.2.5.tgz#093df50a064157e168227e802789c03d69febcc6"
-  integrity sha512-zAz6XS1ZXVXZadcqsOnToiePAKEiEywxOwILEaE4sRl+pVOFQI/30xMiKvjQae1NRK3TbeKxJAmt+yFkPguXJw==
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@fontsource/metropolis/-/metropolis-5.3.0.tgz#f534f5da37e1791a0bb3e649347e16543f6b3aba"
+  integrity sha512-s1KD3SoZdxBgzIKRYGDeIUToIkIHCuIP/t5NUIKh0z1LHU3VqrdLCGxQpNTndI4WuqD1ID+03VfzaTXcDC3MFg==
 
 "@fontsource/roboto@^4.5.5":
   version "4.5.8"
@@ -2649,10 +2649,10 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
-baseline-browser-mapping@^2.10.42:
-  version "2.10.43"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz#7b5d11590ce5acdbe4859443e3c940e81ce8c02d"
-  integrity sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==
+baseline-browser-mapping@^2.10.44:
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.11.1.tgz#390b4714558634093df77add4acca0c5c0c1605e"
+  integrity sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==
 
 batch-processor@1.0.0:
   version "1.0.0"
@@ -2745,13 +2745,13 @@ browserslist@^4.0.0, browserslist@^4.16.3, browserslist@^4.21.4, browserslist@^4
     update-browserslist-db "^1.1.3"
 
 browserslist@^4.24.0:
-  version "4.28.6"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.6.tgz#7cf83afcd69c55fde6fb2dcc5039ff0f4ba42610"
-  integrity sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==
+  version "4.28.7"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.7.tgz#409046517fccd2e51cdc20f077454b7141184028"
+  integrity sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==
   dependencies:
-    baseline-browser-mapping "^2.10.42"
-    caniuse-lite "^1.0.30001803"
-    electron-to-chromium "^1.5.389"
+    baseline-browser-mapping "^2.10.44"
+    caniuse-lite "^1.0.30001806"
+    electron-to-chromium "^1.5.393"
     node-releases "^2.0.51"
     update-browserslist-db "^1.2.3"
 
@@ -2857,7 +2857,7 @@ caniuse-lite@^1.0.30001726:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001734.tgz#f97e08599e2d75664543ae4b6ef25dc2183c5cc6"
   integrity sha512-uhE1Ye5vgqju6OI71HTQqcBCZrvHugk0MjLak7Q+HfoBgoq5Bi+5YnwjP4fjDgrtYr/l8MVRBvzz9dPD4KyK0A==
 
-caniuse-lite@^1.0.30001803:
+caniuse-lite@^1.0.30001806:
   version "1.0.30001806"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz#1bc8e502b723fa393455dfbedd5ccec0c29bb74e"
   integrity sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==
@@ -3633,10 +3633,10 @@ electron-to-chromium@^1.5.173:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.200.tgz#adffa5db97390ce9d48987f528117a608ed0d7c9"
   integrity sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==
 
-electron-to-chromium@^1.5.389:
-  version "1.5.393"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz#aec971df2a6f4f7e51fbacb200d66cebfc7d3c17"
-  integrity sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==
+electron-to-chromium@^1.5.393:
+  version "1.5.396"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz#4aa96428486c8d1c9c8aeb205b2d6e04928ca046"
+  integrity sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -5622,10 +5622,15 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
 
-lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.23:
+lodash@^4.17.20, lodash@^4.17.23:
   version "4.17.23"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
   integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+
+lodash@^4.17.21:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^4.1.0:
   version "4.1.0"
@@ -6204,11 +6209,12 @@ ora@^5.3.0:
     wcwidth "^1.0.1"
 
 own-keys@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/own-keys/-/own-keys-1.0.1.tgz#e4006910a2bf913585289676eebd6f390cf51358"
-  integrity sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/own-keys/-/own-keys-1.0.2.tgz#31448ec1f781ecb1447f6f6aa0d6534222af59de"
+  integrity sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==
   dependencies:
-    get-intrinsic "^1.2.6"
+    call-bound "^1.0.4"
+    get-intrinsic "^1.3.0"
     object-keys "^1.1.1"
     safe-push-apply "^1.0.0"
 
@@ -8277,8 +8283,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.62.29"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#9926c3913aadcfe3525c38e83d6a5c993432019a"
+  version "1.62.36"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#0d1f5acffdf60948fdf435998b388156cb2b5b12"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
## Summary

Add Firewall app Vue UI wrapper component for the ExtJS → Vue migration, connecting the shared vuntangle Firewall component to the NGFW host app via `appMixin`.

## Motivation

NGFW-15901: Migrate the Firewall app frontend from ExtJS to Vue. This wrapper is the NGFW-side integration point that handles backend communication (settings load/save, power toggle, app removal) and passes data down to the shared vuntangle Firewall component.

## Changes

### Firewall App Wrapper (`Apps/apps/Firewall/Firewall.vue`)
- New component using `appMixin` for lifecycle management, metrics, reports, and power state
- Renders the shared `<firewall>` component from vuntangle with `settings`, `consolidatedAppData`, `formattedMetrics`, and `appReports` props
- Action bar with `UAppStatusRemove`, Refresh, and Save buttons via `#actions` slot
- Auto-discovered by `AppSettingsLayout` via dynamic import convention (`./apps/Firewall/Firewall.vue`)

## Testing

1. Navigate to `/apps/{policyId}/firewall`
2. Verify the Firewall app loads with Status and Rules tabs
3. Toggle power on/off and verify state transitions
4. Click Remove — verify confirmation dialog and app uninstall
5. Click Refresh — verify settings reload
6. Verify Save button is disabled when no changes are made

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
