### PR TITLE
NGFW-15899 Import report functionality changes

### DIFF
--- a/untangle-vue-ui/source/src/components/reports/Reports.vue
+++ b/untangle-vue-ui/source/src/components/reports/Reports.vue
@@ -9,6 +9,7 @@
     @set-conditions="onSetConditions"
     @view-report="onViewReport"
     @export-category="onExportCategory"
+    @import-reports="onImportReports"
   >
     <template #actions>
       <u-btn @click="onExportAll">{{ $t('export') }}</u-btn>
@@ -33,6 +34,7 @@
           showViewMore: true,
           maximizableCards: true,
           exportable: true,
+          importable: true,
           enableSearch: true,
         },
       }
@@ -55,6 +57,70 @@
 
       async onExportAll() {
         await exportCategoryReports(this.allReports)
+      },
+
+      /**
+       * Handles importing reports by validating titles, checking for conflicts,
+       * and dispatching the import action to the store.
+       * Dialog stays open on validation/import failure; closes only on success via callback.
+       *
+       * @param {Object} params - The import parameters
+       * @param {Array<Object>} params.reports - Array of report objects to import
+       * @param {boolean} params.replaceAll - If true, replaces all existing reports; otherwise merges with conflict check
+       * @param {Function} params.cb - Callback to signal success/failure to the dialog
+       */
+      async onImportReports({ reports, replaceAll, cb }) {
+        const hasEmptyTitle = reports.some(r => !r.title || !r.title.trim())
+        if (hasEmptyTitle) {
+          this.$vuntangle.toast.add(this.$t('report_title_required'), 'error')
+          cb(new Error('report_title_required'), false)
+          return
+        }
+
+        if (!replaceAll) {
+          const existingTitleSet = new Set(this.allReports.map(r => r.title))
+          const hasConflicts = reports.some(r => existingTitleSet.has(r.title))
+          if (hasConflicts) {
+            this.$vuntangle.toast.add(this.$t('import_reports_conflict_error'), 'error')
+            cb(new Error('import_reports_conflict_error'), false)
+            return
+          }
+        }
+
+        const preparedReports = this.prepareReportsForImport(reports, replaceAll)
+        const result = await this.$store.dispatch('reports/importReports', { reports: preparedReports, replaceAll })
+        if (result.success) {
+          this.$vuntangle.toast.add(`${preparedReports.length} Report(s) imported!`)
+          cb(null, true)
+          if (preparedReports.length === 1) {
+            this.onViewReport(preparedReports[0].uniqueId)
+          }
+        } else {
+          cb(result.error || new Error('import_failed'), false)
+        }
+      },
+
+      /**
+       * Prepares report objects for import by stripping computed/internal fields
+       * and assigning new unique IDs where necessary to avoid collisions.
+       *
+       * @param {Array<Object>} reports - Raw report objects from the imported file
+       * @param {boolean} replaceAll - If true, preserves existing uniqueIds; otherwise regenerates on conflict
+       * @returns {Array<Object>} Cleaned report objects ready for store dispatch
+       */
+      prepareReportsForImport(reports, replaceAll) {
+        const COMPUTED_FIELDS = ['localizedTitle', 'localizedDescription', 'slug', 'categorySlug', 'url', 'icon', '_id']
+        const existingIdSet = new Set(this.allReports.map(r => r.uniqueId))
+
+        return reports.map(r => {
+          const rep = { ...r }
+          COMPUTED_FIELDS.forEach(f => delete rep[f])
+          delete rep._importIndex
+          if (!rep.uniqueId || (!replaceAll && existingIdSet.has(rep.uniqueId))) {
+            rep.uniqueId = 'report-' + Math.random().toString(36).substring(2)
+          }
+          return rep
+        })
       },
     },
   }

--- a/untangle-vue-ui/source/src/components/reports/Reports.vue
+++ b/untangle-vue-ui/source/src/components/reports/Reports.vue
@@ -116,6 +116,7 @@
           const rep = { ...r }
           COMPUTED_FIELDS.forEach(f => delete rep[f])
           delete rep._importIndex
+          rep.javaClass = 'com.untangle.app.reports.ReportEntry'
           if (!rep.uniqueId || (!replaceAll && existingIdSet.has(rep.uniqueId))) {
             rep.uniqueId = 'report-' + Math.random().toString(36).substring(2)
           }

--- a/untangle-vue-ui/source/src/store/reports.js
+++ b/untangle-vue-ui/source/src/store/reports.js
@@ -234,6 +234,31 @@ const actions = {
   },
 
   /**
+   * Imports report entries into the backend via the full settings path.
+   * Uses the same getSettingsV2/setSettingsV2 pattern as store/apps.js.
+   *
+   * @param {Object} payload
+   * @param {Array}  payload.reports    - prepared ReportEntry objects to import
+   * @param {boolean} payload.replaceAll - true replaces all entries, false appends
+   * @returns {Object} { success: boolean, error?: Error }
+   */
+  async importReports({ state, dispatch }, { reports, replaceAll }) {
+    const reportsManager = state.reportsManager
+    if (!reportsManager) {
+      return { success: false, error: new Error('Reports manager not available') }
+    }
+
+    try {
+      await Rpc.asyncData(reportsManager, 'importReportEntriesV2', reports, replaceAll)
+      await dispatch('loadReports')
+      return { success: true }
+    } catch (error) {
+      Util.handleException(error, 'Failed to import reports')
+      return { success: false, error }
+    }
+  },
+
+  /**
    * Fetches policy name/ID pairs from the backend for EVENT_LIST detail rendering.
    * Only runs once — returns immediately if policiesInfo is already populated.
    * Returns an empty list when no policy-manager is installed.

--- a/untangle-vue-ui/source/src/store/reports.js
+++ b/untangle-vue-ui/source/src/store/reports.js
@@ -234,22 +234,38 @@ const actions = {
   },
 
   /**
-   * Imports report entries into the backend via the full settings path.
-   * Uses the same getSettingsV2/setSettingsV2 pattern as store/apps.js.
+   * Imports report entries in bulk by fetching the full ReportsSettings via getSettingsV2,
+   * updating its reportEntries array (replace or append), and saving back via setSettingsV2.
+   * After saving, dispatches loadReports to refresh the store from getReportEntriesV2.
+   *
+   * Reports should already be cleaned by the caller (transient fields stripped,
+   * javaClass set, uniqueIds assigned or preserved based on replaceAll).
    *
    * @param {Object} payload
-   * @param {Array}  payload.reports    - prepared ReportEntry objects to import
-   * @param {boolean} payload.replaceAll - true replaces all entries, false appends
+   * @param {Array}  payload.reports    - cleaned ReportEntry objects ready for backend
+   * @param {boolean} payload.replaceAll - if true, replaces all existing entries; if false, appends to existing
    * @returns {Object} { success: boolean, error?: Error }
    */
-  async importReports({ state, dispatch }, { reports, replaceAll }) {
-    const reportsManager = state.reportsManager
-    if (!reportsManager) {
-      return { success: false, error: new Error('Reports manager not available') }
-    }
-
+  async importReports({ dispatch }, { reports, replaceAll }) {
     try {
-      await Rpc.asyncData(reportsManager, 'importReportEntriesV2', reports, replaceAll)
+      const reportsApp = await Rpc.asyncData('rpc.appManager.app', 'reports')
+      if (!reportsApp) {
+        return { success: false, error: new Error('Reports app not available') }
+      }
+
+      const settings = await Rpc.asyncData(reportsApp, 'getSettingsV2')
+      if (!settings) {
+        return { success: false, error: new Error('Failed to load reports settings') }
+      }
+
+      if (replaceAll) {
+        settings.reportEntries = reports
+      } else {
+        settings.reportEntries = [...(settings.reportEntries || []), ...reports]
+      }
+
+      await Rpc.asyncData(reportsApp, 'setSettingsV2', settings)
+
       await dispatch('loadReports')
       return { success: true }
     } catch (error) {


### PR DESCRIPTION
- Added import reports functionality to the Reports page
- Implemented `onImportReports` handler with validation (empty titles, duplicate title conflicts) and `prepareReportsForImport` to strip computed fields and handle uniqueId collisions
- Added `importReports` Vuex action using `reportsManager.importReportEntriesV2` with error handling
- Enabled `importable: true` in Reports component config and wired `@import-reports` event
<img width="1919" height="1060" alt="image" src="https://github.com/user-attachments/assets/582ff8c0-a04b-4d99-b959-b3431bb7848e" />
<img width="1910" height="1032" alt="image" src="https://github.com/user-attachments/assets/0ddd86c1-21bd-4b7b-ba83-3334f45952af" />
