### PR TITLE
ngfw-15928: Prevent cascade failures in About page and handle fetchStatus errors gracefully

### DIFF
--- a/untangle-vue-ui/source/src/components/settings/services/DynamicBlockLists.vue
+++ b/untangle-vue-ui/source/src/components/settings/services/DynamicBlockLists.vue
@@ -73,6 +73,8 @@
         try {
           const response = await window.rpc.appManager.app('dynamic-blocklists').status()
           this.status = response || []
+        } catch {
+          this.status = []
         } finally {
           this.$store.commit('SET_LOADER', false)
         }

--- a/untangle-vue-ui/source/src/components/settings/system/About.vue
+++ b/untangle-vue-ui/source/src/components/settings/system/About.vue
@@ -64,39 +64,45 @@
         this.$store.commit('SET_LOADER', true) // Activate loader
         try {
           // Execute multiple RPC calls concurrently to get server data
-          const [kernel, history, reboots, currentActive, maxActive, build, uid, serial, region] = await Promise.all([
-            window.rpc.adminManager.getKernelVersion(), // Kernel version
-            window.rpc.adminManager.getModificationState(), // Modification state
-            window.rpc.adminManager.getRebootCount(), // Reboot count
-            window.rpc.hostTable.getCurrentActiveSize(), // Current active device count
-            window.rpc.hostTable.getMaxActiveSize(), // Max active device count since reboot
-            window.rpc.fullVersionAndRevision, // Full version and revision
-            window.rpc.serverUID, // Server UID
-            window.rpc.serverSerialnumber, // Server serial number
-            window.rpc.regionName, // Region name
+          const results = await Promise.allSettled([
+            Promise.resolve().then(() => window.rpc.adminManager.getKernelVersion()), // Kernel version
+            Promise.resolve().then(() => window.rpc.adminManager.getModificationState()), // Modification state
+            Promise.resolve().then(() => window.rpc.adminManager.getRebootCount()), // Reboot count
+            Promise.resolve().then(() => window.rpc.hostTable.getCurrentActiveSize()), // Current active device count
+            Promise.resolve().then(() => window.rpc.hostTable.getMaxActiveSize()), // Max active device count since reboot
+            Promise.resolve().then(() => window.rpc.fullVersionAndRevision), // Full version and revision
+            Promise.resolve().then(() => window.rpc.serverUID), // Server UID
+            Promise.resolve().then(() => window.rpc.serverSerialnumber), // Server serial number
+            Promise.resolve().then(() => window.rpc.regionName), // Region name
           ])
 
+          const value = r => (r.status === 'fulfilled' ? r.value : undefined)
+          const [kernel, history, reboots, currentActive, maxActive, build, uid, serial, region] = results.map(value)
+
           // Initialize data array with UID
-          const data = [{ name: 'uid_name', value: uid }]
+          const data = []
+          if (uid != null) data.push({ name: 'uid_name', value: uid })
           // Add serial number if available
           if (serial) data.push({ name: 'serial_number', value: serial })
 
           // Fetch account info if UID is valid
           if (uid && uid.length === 19) {
-            const account = await util.fetchAccountInfo(uid)
-            if (account && account.account) data.push({ name: 'account', value: account.account })
+            try {
+              const account = await util.fetchAccountInfo(uid)
+              if (account?.account) data.push({ name: 'account', value: account.account })
+            } catch {
+              // external store unreachable — skip Account row, keep everything else
+            }
           }
 
           // Add remaining server data to the array
-          data.push(
-            { name: 'build', value: build },
-            { name: 'kernel', value: kernel },
-            { name: 'region', value: region },
-            { name: 'history', value: history },
-            { name: 'reboots', value: reboots },
-            { name: 'current_active_device_count', value: currentActive },
-            { name: 'highest_active_device_count_since_reboot', value: maxActive },
-          )
+          if (build != null) data.push({ name: 'build', value: build })
+          if (kernel != null) data.push({ name: 'kernel', value: kernel })
+          if (region != null) data.push({ name: 'region', value: region })
+          if (history != null) data.push({ name: 'history', value: history })
+          if (reboots != null) data.push({ name: 'reboots', value: reboots })
+          if (currentActive != null) data.push({ name: 'current_active_device_count', value: currentActive })
+          if (maxActive != null) data.push({ name: 'highest_active_device_count_since_reboot', value: maxActive })
 
           // Update component's serverData
           this.serverData = data

--- a/untangle-vue-ui/source/src/components/settings/system/About.vue
+++ b/untangle-vue-ui/source/src/components/settings/system/About.vue
@@ -63,21 +63,24 @@
       async getServerData() {
         this.$store.commit('SET_LOADER', true) // Activate loader
         try {
+          const safe = fn => Promise.resolve().then(fn)
+          const rpc = window.rpc
+
           // Execute multiple RPC calls concurrently to get server data
           const results = await Promise.allSettled([
-            Promise.resolve().then(() => window.rpc.adminManager.getKernelVersion()), // Kernel version
-            Promise.resolve().then(() => window.rpc.adminManager.getModificationState()), // Modification state
-            Promise.resolve().then(() => window.rpc.adminManager.getRebootCount()), // Reboot count
-            Promise.resolve().then(() => window.rpc.hostTable.getCurrentActiveSize()), // Current active device count
-            Promise.resolve().then(() => window.rpc.hostTable.getMaxActiveSize()), // Max active device count since reboot
-            Promise.resolve().then(() => window.rpc.fullVersionAndRevision), // Full version and revision
-            Promise.resolve().then(() => window.rpc.serverUID), // Server UID
-            Promise.resolve().then(() => window.rpc.serverSerialnumber), // Server serial number
-            Promise.resolve().then(() => window.rpc.regionName), // Region name
+            safe(() => rpc.adminManager.getKernelVersion()), // Kernel version
+            safe(() => rpc.adminManager.getModificationState()), // Modification state
+            safe(() => rpc.adminManager.getRebootCount()), // Reboot count
+            safe(() => rpc.hostTable.getCurrentActiveSize()), // Current active device count
+            safe(() => rpc.hostTable.getMaxActiveSize()), // Max active device count since reboot
+            safe(() => rpc.fullVersionAndRevision), // Full version and revision
+            safe(() => rpc.serverUID), // Server UID
+            safe(() => rpc.serverSerialnumber), // Server serial number
+            safe(() => rpc.regionName), // Region name
           ])
 
-          const value = r => (r.status === 'fulfilled' ? r.value : undefined)
-          const [kernel, history, reboots, currentActive, maxActive, build, uid, serial, region] = results.map(value)
+          const val = r => (r.status === 'fulfilled' ? r.value : undefined)
+          const [kernel, history, reboots, currentActive, maxActive, build, uid, serial, region] = results.map(val)
 
           // Initialize data array with UID
           const data = []
@@ -86,23 +89,28 @@
           if (serial) data.push({ name: 'serial_number', value: serial })
 
           // Fetch account info if UID is valid
-          if (uid && uid.length === 19) {
+          if (uid?.length === 19) {
             try {
               const account = await util.fetchAccountInfo(uid)
               if (account?.account) data.push({ name: 'account', value: account.account })
             } catch {
-              // external store unreachable — skip Account row, keep everything else
+              // external store unreachable
             }
           }
 
           // Add remaining server data to the array
-          if (build != null) data.push({ name: 'build', value: build })
-          if (kernel != null) data.push({ name: 'kernel', value: kernel })
-          if (region != null) data.push({ name: 'region', value: region })
-          if (history != null) data.push({ name: 'history', value: history })
-          if (reboots != null) data.push({ name: 'reboots', value: reboots })
-          if (currentActive != null) data.push({ name: 'current_active_device_count', value: currentActive })
-          if (maxActive != null) data.push({ name: 'highest_active_device_count_since_reboot', value: maxActive })
+          const fields = [
+            ['build', build],
+            ['kernel', kernel],
+            ['region', region],
+            ['history', history],
+            ['reboots', reboots],
+            ['current_active_device_count', currentActive],
+            ['highest_active_device_count_since_reboot', maxActive],
+          ]
+          for (const [name, value] of fields) {
+            if (value != null) data.push({ name, value })
+          }
 
           // Update component's serverData
           this.serverData = data

--- a/untangle-vue-ui/source/src/util/util.js
+++ b/untangle-vue-ui/source/src/util/util.js
@@ -515,6 +515,7 @@ const util = {
    * @returns {Promise<string>} The formatted store URL.
    */
   async getStoreUrl() {
+    if (!window.rpc?.storeUrl) return null
     const url = await window.rpc.storeUrl.replace('/api/v1', '/store/open.php')
     return url
   },
@@ -534,6 +535,7 @@ const util = {
    */
   async fetchAccountInfo(uid) {
     const storeUrl = await this.getStoreUrl()
+    if (!storeUrl) throw new Error('storeUrl is not available')
 
     return new Promise((resolve, reject) => {
       const script = document.createElement('script')


### PR DESCRIPTION


This PR improves UI resilience by preventing a single RPC or external call failure from causing an entire page to fail.

### Changes
**About.vue**

- Replaced Promise.all with Promise.allSettled in getServerData().
- Wrapped synchronous RPC calls with Promise.resolve().then(...) so synchronous exceptions are converted into promise rejections that Promise.allSettled can process.
- Added per-result handling using the returned status field:

          fulfilled → use the returned value.
          rejected → skip the failed field and continue rendering the page.
          
- Preserves all successfully retrieved data even when one or more RPC calls fail.


**DynamicBlockLists.vue**

- Added a missing catch block to fetchStatus().
- On failure:

        Reset status to an empty array.
        Prevent unhandled promise rejections.

- Existing success and cleanup (finally) behavior remains unchanged.


### Testing Performed

- Verified the About page continues to render available server information when getKernelVersion() RPC fails, with only the failed field omitted.
- Verified the About page remains functional when fetchAccountInfo fails (by blocking the external store URL), preserving all successfully loaded data.
- Verified the About page handles an undefined window.rpc.storeUrl without causing the page to go blank or crashing.
- Verified the Dynamic Block Lists page gracefully handles a failed fetchStatus() call by clearing the status list, preventing an unhandled exception, and correctly dismissing the loader.

