### PR TITLE
ngfw-15921 Threat Prevention component added

### DIFF
--- a/untangle-vue-ui/source/src/components/Apps/apps/ThreatPrevention/ThreatPrevention.vue
+++ b/untangle-vue-ui/source/src/components/Apps/apps/ThreatPrevention/ThreatPrevention.vue
@@ -1,0 +1,81 @@
+<template>
+  <threat-prevention
+    :settings="settings"
+    :app-data="consolidatedAppData"
+    :metrics-data="formattedMetrics"
+    :reports="appReports"
+    @toggle-state="toggleAppState"
+  >
+    <!-- Custom action buttons slot -->
+    <template #actions="{ newSettings, isDirty }">
+      <div class="d-flex flex-wrap align-center" style="gap: 8px">
+        <div style="min-width: 140px">
+          <u-app-status-remove class="mt-0" :app-name="appDisplayName" @remove="removeApp" />
+        </div>
+        <v-divider vertical class="mx-4" />
+        <u-btn class="mr-2" @click="refreshData">{{ $t('refresh') }}</u-btn>
+        <u-btn :disabled="!isDirty || saveDisabled" @click="saveSettings(newSettings)">{{ $t('save') }}</u-btn>
+      </div>
+    </template>
+  </threat-prevention>
+</template>
+
+<script>
+  import { ThreatPrevention, UAppStatusRemove } from 'vuntangle'
+  import { VDivider } from 'vuetify/lib'
+  import appMixin from '../appMixin'
+  import conditionDataMixin from '../conditionDataMixin'
+  import util from '@/util/util'
+
+  export default {
+    name: 'ThreatPreventionApp',
+
+    components: {
+      ThreatPrevention,
+      UAppStatusRemove,
+      VDivider,
+    },
+
+    mixins: [appMixin, conditionDataMixin(['directory-connector'])],
+
+    provide() {
+      return {
+        $remoteData: () => ({
+          interfaces: this.interfaces,
+          directoryGroups: this.directoryGroups,
+          directoryDomains: this.directoryDomains,
+          directoryUsers: this.directoryUsers,
+        }),
+        $features: { isExpertMode: this.isExpertMode, hasFlaggedAction: true },
+        $readOnly: false,
+        $applications: {},
+      }
+    },
+
+    props: {
+      appData: { type: Object, default: null },
+    },
+
+    data() {
+      return {
+        appName: this.appData?.appName || 'threat-prevention',
+        defaultDisplayName: 'Threat Prevention',
+      }
+    },
+
+    computed: {
+      // Get the consolidated app data for the threat prevention app.
+      consolidatedAppData: appInstance => appInstance.buildConsolidatedAppData(),
+      // Get the network settings from the store and extract the interfaces.
+      networkSettings: ({ $store }) => $store.getters['config/networkSetting'],
+      interfaces: ({ networkSettings }) => util.getInterfaceList(networkSettings, true, true),
+      // Get isExpertMode from the store.
+      isExpertMode: ({ $store }) => $store.getters['config/isExpertMode'],
+    },
+
+    created() {
+      // Fetch the network settings when the component is created.
+      this.$store.dispatch('config/getNetworkSettings', false)
+    },
+  }
+</script>

--- a/untangle-vue-ui/source/src/store/metrics.js
+++ b/untangle-vue-ui/source/src/store/metrics.js
@@ -25,7 +25,6 @@ const state = () => ({
   isPolling: false, // Polling state flags
   lastUpdate: null,
   error: null,
-  expertMode: false, // When false, metrics with expert: true are hidden
 })
 
 const getters = {
@@ -67,14 +66,15 @@ const getters = {
    * @param {string|number} instanceId - App instance ID
    * @returns {Array} Array of {key, value, formatter} objects for UAppStatusMetrics
    */
-  getFormattedMetrics: state => instanceId => {
+  getFormattedMetrics: (state, getters, rootState, rootGetters) => instanceId => {
     if (!instanceId) return []
 
     const appMetrics = state.appMetrics[String(instanceId)]
     if (!appMetrics) return []
 
+    const isExpertMode = rootGetters['config/isExpertMode']
     return appMetrics
-      .filter(metric => !metric.expert || state.expertMode)
+      .filter(metric => !metric.expert || isExpertMode)
       .map(metric => ({
         key: metric.displayName,
         value: metric.value + (metric.displayUnits ? ' ' + metric.displayUnits : ''),
@@ -114,12 +114,6 @@ const getters = {
    * @returns {Object} System stats object
    */
   systemStats: state => state.systemStats,
-
-  /**
-   * Get expert mode state
-   * @returns {boolean} True if expert mode is enabled
-   */
-  expertMode: state => state.expertMode,
 
   /**
    * Get current error (if any)
@@ -166,15 +160,6 @@ const mutations = {
   },
 
   /**
-   * Set expert mode
-   * @param {Object} state - Vuex state
-   * @param {boolean} expertMode - True if expert mode is enabled
-   */
-  SET_EXPERT_MODE(state, expertMode) {
-    state.expertMode = expertMode
-  },
-
-  /**
    * Clear all metrics (on logout/cleanup)
    * Resets state to initial values
    */
@@ -187,23 +172,6 @@ const mutations = {
 }
 
 const actions = {
-  /**
-   * Initialize expert mode from RPC
-   *
-   * Should be called once during app initialization
-   * Fetches expert mode state from backend
-   */
-  async initExpertMode({ commit }) {
-    try {
-      const expertMode = await window.rpc.isExpertMode
-      commit('SET_EXPERT_MODE', expertMode)
-      return { success: true, expertMode }
-    } catch (err) {
-      commit('SET_EXPERT_MODE', false)
-      return { success: false, error: err }
-    }
-  },
-
   /**
    * Update metrics data (called by polling service)
    *

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -8311,8 +8311,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.62.55"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#83def97ae3fb4c0935510e121fdfb2186df4080b"
+  version "1.62.57"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#5e39a09902ac7a466972983052049a4c81b42590"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
## Summary

Adds the NGFW-specific Threat Prevention Vue wrapper component and fixes the expert mode metrics bug that prevented "Lookup time average" and other expert metrics from displaying across all apps.

## Motivation

NGFW-15921 — Vue UI migration for the Threat Prevention app. The NGFW Vue UI needed a wrapper component to host the shared vuntangle `ThreatPrevention` component with NGFW-specific context (RPC, store bindings, action buttons). Additionally, the metrics store had a dead `expertMode` state that was never initialized, causing expert metrics to be permanently hidden.

## Changes

### Threat Prevention Wrapper (`components/Apps/apps/ThreatPrevention/ThreatPrevention.vue`)
- New NGFW-specific wrapper component using `appMixin` and `conditionDataMixin(['directory-connector'])`
- Provides `$remoteData` (interfaces, directory groups/domains/users), `$features` (isExpertMode, hasFlaggedAction), `$readOnly`, `$applications` to child components
- Renders Save, Refresh, and Remove action buttons via the `#actions` slot
- Fetches network settings on `created` for interface list

### Metrics Store Bug Fix (`store/metrics.js`)
- `getFormattedMetrics` now reads expert mode from `rootGetters['config/isExpertMode']` (the canonical source used by all other components) instead of the local `state.expertMode` which was never initialized
- Removed dead code: `expertMode` state property, `expertMode` getter, `SET_EXPERT_MODE` mutation, `initExpertMode` action — none were called from anywhere, leaving `expertMode` permanently `false` and hiding all expert metrics

## Testing

1. Navigate to the Threat Prevention app in the Vue UI
2. **Status tab**: Verify all metrics display in expertMode, including "Lookup time average" (expert metric)
3. **Action buttons**: Verify Save (disabled when clean, enabled when dirty), Refresh, and Remove work correctly
4. **Other apps**: Verify that expert metrics now display correctly for any app that has them (this was a global bug)

## Checklist

- [x] Code compiles and existing tests pass
- [x] New behavior is manually verified
- [x] No unintended side-effects in related features
