### PR TITLE
NGFW-15931 General Settings and Data source tab implementation

### DIFF
--- a/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
+++ b/untangle-vue-ui/source/src/components/reports/ReportDetails.vue
@@ -6,6 +6,7 @@
       :categories="categoriesForNav"
       :show-report-selector="true"
       :show-auto-refresh="true"
+      :show-settings="true"
       :is-local-ui="false"
       @add-condition="onAddCondition"
       @remove-condition="onRemoveCondition"
@@ -15,6 +16,7 @@
       @view-report="onViewReport"
       @export-all-events="onExportAllEvents"
       @auto-refresh-change="onAutoRefreshChange"
+      @edit-report="onEditReport"
     />
 
     <!-- Settings diff dialog — opened by the  action column on settings_changes rows -->

--- a/untangle-vue-ui/source/src/components/reports/ReportEdit.vue
+++ b/untangle-vue-ui/source/src/components/reports/ReportEdit.vue
@@ -1,0 +1,121 @@
+<template>
+  <report-edit
+    :report="report"
+    :categories="allCategories"
+    :existing-reports="allReports"
+    :table-fields="translatedTableFields"
+    :condition-operators="globalConditionOperators"
+    @save="onSave"
+    @delete="onDelete"
+    @cancel="onCancel"
+    @refresh="onRefresh"
+  />
+</template>
+
+<script>
+  import { mapGetters } from 'vuex'
+  import { ReportEdit } from 'vuntangle'
+  import reportsMixin from './reportsMixin'
+  import { urlEncode } from '@/util/reports'
+
+  export default {
+    name: 'ReportEditPage',
+    components: { ReportEdit },
+    mixins: [reportsMixin],
+
+    computed: {
+      ...mapGetters('reports', ['allCategories']),
+
+      /**
+       * Resolves the report entry from the store using the current route params.
+       * Returns null for the create route so the editor starts with a blank form.
+       */
+      report() {
+        if (this.$route.name === 'report-create') return null
+        const { cat, rep } = this.$route.params
+        return this.allReports.find(r => urlEncode(r.category) === cat && urlEncode(r.title) === rep) || null
+      },
+    },
+
+    methods: {
+      /**
+       * Persists a new or updated report entry to the backend.
+       * Generates a uniqueId for new reports, then navigates to the detail view on success.
+       *
+       * @param {Object} entry - the report definition from the editor form
+       */
+      async onSave(entry) {
+        const isNew = !entry.uniqueId
+        if (isNew) {
+          entry.uniqueId = 'report-' + Math.random().toString(36).substr(2)
+        }
+
+        this.$store.commit('SET_LOADER', true)
+        try {
+          const result = await this.$store.dispatch('reports/saveReport', entry)
+          if (result.success) {
+            const successMessage = isNew ? 'report_created' : 'report_updated'
+            this.$vuntangle.toast.add(this.$t(successMessage, { title: entry.title }))
+            this.$router.push({
+              name: 'report-details',
+              params: { cat: urlEncode(entry.category), rep: urlEncode(entry.title) },
+            })
+          } else {
+            this.$vuntangle.toast.add(this.$t('report_save_failed'), 'error')
+          }
+        } catch (error) {
+          this.$vuntangle.toast.add(this.$t('report_save_failed'), 'error')
+        } finally {
+          this.$store.commit('SET_LOADER', false)
+        }
+      },
+
+      /**
+       * Deletes a report after user confirmation.
+       * Shows a confirm dialog, then dispatches the delete action and navigates
+       * back to the reports list on success.
+       *
+       * @param {Object} entry - the report entry to delete
+       */
+      onDelete(entry) {
+        this.$vuntangle.confirm.show({
+          title: this.$t('warning'),
+          message: this.$t('delete_report_confirm'),
+          confirmLabel: this.$t('yes'),
+          cancelLabel: this.$t('no'),
+          action: async resolve => {
+            resolve()
+            this.$store.commit('SET_LOADER', true)
+            try {
+              const result = await this.$store.dispatch('reports/deleteReport', entry)
+              if (result.success) {
+                this.$vuntangle.toast.add(this.$t('report_deleted', { title: entry.title }))
+                this.$router.push({ name: 'reports' })
+              } else {
+                this.$vuntangle.toast.add(this.$t('report_delete_failed'), 'error')
+              }
+            } catch (error) {
+              this.$vuntangle.toast.add(this.$t('report_delete_failed'), 'error')
+            } finally {
+              this.$store.commit('SET_LOADER', false)
+            }
+          },
+        })
+      },
+
+      /** Reloads the full report list from the backend. */
+      async onRefresh() {
+        await this.$store.dispatch('reports/loadReports')
+      },
+      /** Navigates back to the report detail view (edit mode) or the reports list (create mode). */
+      onCancel() {
+        if (this.$route.name === 'report-edit') {
+          const { cat, rep } = this.$route.params
+          this.$router.push({ name: 'report-details', params: { cat, rep } })
+        } else {
+          this.$router.push({ name: 'reports' })
+        }
+      },
+    },
+  }
+</script>

--- a/untangle-vue-ui/source/src/components/reports/Reports.vue
+++ b/untangle-vue-ui/source/src/components/reports/Reports.vue
@@ -10,6 +10,7 @@
     @view-report="onViewReport"
     @export-category="onExportCategory"
     @import-reports="onImportReports"
+    @add-report="onEditReport"
   >
     <template #actions>
       <u-btn @click="onExportAll">{{ $t('export') }}</u-btn>

--- a/untangle-vue-ui/source/src/components/reports/reportsMixin.js
+++ b/untangle-vue-ui/source/src/components/reports/reportsMixin.js
@@ -13,11 +13,16 @@ export default {
       $conditionValueOptions: () => conditionValueOptions,
       $disabledReportIds: () => this.disabledReportIds,
       $conditionTableFields: () => this.translatedTableFields,
+      $tables: () => this.tables,
     }
   },
 
+  created() {
+    this.$store.dispatch('reports/fetchTables')
+  },
+
   computed: {
-    ...mapGetters('reports', ['allReports', 'globalConditions']),
+    ...mapGetters('reports', ['allReports', 'globalConditions', 'tables']),
 
     /** Translates operator options for the global condition dropdowns. */
     globalConditionOperators() {
@@ -82,6 +87,21 @@ export default {
           rep: urlEncode(report.title),
         },
       })
+    },
+
+    /**
+     * Navigates to the report editor for the given uniqueId.
+     * If no uniqueId is provided, navigates to the create-new-report route.
+     * @param {String} uniqueId - the report's uniqueId, or falsy to create a new report
+     */
+    onEditReport(uniqueId) {
+      if (!uniqueId) {
+        this.$router.push('/reports/create')
+        return
+      }
+      const report = this.allReports.find(r => r.uniqueId === uniqueId)
+      if (!report) return
+      this.$router.push(`/reports/edit/${urlEncode(report.category)}/${urlEncode(report.title)}`)
     },
 
     /** Adds a new global condition to the Vuex store. */

--- a/untangle-vue-ui/source/src/router/reports.js
+++ b/untangle-vue-ui/source/src/router/reports.js
@@ -1,5 +1,6 @@
 import Reports from '@/components/reports/Reports.vue'
 import ReportDetails from '@/components/reports/ReportDetails.vue'
+import ReportEdit from '@/components/reports/ReportEdit.vue'
 
 export default [
   {
@@ -13,5 +14,17 @@ export default [
     path: '/reports/:cat/:rep',
     component: ReportDetails,
     meta: { helpContext: 'report-details' },
+  },
+  {
+    name: 'report-create',
+    path: '/reports/create',
+    component: ReportEdit,
+    meta: { helpContext: 'report-edit' },
+  },
+  {
+    name: 'report-edit',
+    path: '/reports/edit/:cat/:rep',
+    component: ReportEdit,
+    meta: { helpContext: 'report-edit' },
   },
 ]

--- a/untangle-vue-ui/source/src/store/reports.js
+++ b/untangle-vue-ui/source/src/store/reports.js
@@ -41,6 +41,9 @@ const getDefaultState = () => ({
   // Each condition: { column, operator, value, autoFormatValue }
   globalConditions: [],
 
+  // Available database tables — fetched lazily via reportsManager.getTables()
+  tables: [],
+
   // Unique key per login session — used by DateTimeRangePresets to reset saved state on logout/login
   timeRangeSessionKey: null,
 })
@@ -90,6 +93,7 @@ const getters = {
    * Populated lazily by fetchPoliciesInfo when an EVENT_LIST report is opened.
    * Returns an empty map when no policy-manager is installed.
    */
+  tables: state => state.tables,
   globalConditions: state => state.globalConditions,
   timeRangeSessionKey: state => state.timeRangeSessionKey,
 
@@ -141,6 +145,10 @@ const mutations = {
 
   SET_LAST_LOADED(state, timestamp) {
     state.lastLoaded = timestamp
+  },
+
+  SET_TABLES(state, tables) {
+    state.tables = tables
   },
 
   SET_POLICIES_INFO(state, policies) {
@@ -271,6 +279,57 @@ const actions = {
     } catch (error) {
       Util.handleException(error, 'Failed to import reports')
       return { success: false, error }
+    }
+  },
+
+  /**
+   * Persists a report entry to the backend via the reportsManager RPC,
+   * then reloads the full report list to keep the store in sync.
+   *
+   * @param {Object} entry - the ReportEntry object to create or update
+   * @returns {Object} { success: boolean, error?: Error }
+   */
+  async saveReport({ state, dispatch }, entry) {
+    try {
+      await Rpc.asyncData(state.reportsManager, 'saveReportEntry', entry)
+      await dispatch('loadReports')
+      return { success: true }
+    } catch (error) {
+      Util.handleException(error, 'Failed to save report')
+      return { success: false, error }
+    }
+  },
+
+  /**
+   * Removes a report entry from the backend via the reportsManager RPC,
+   * then reloads the full report list to keep the store in sync.
+   *
+   * @param {Object} entry - the ReportEntry object to delete
+   * @returns {Object} { success: boolean, error?: Error }
+   */
+  async deleteReport({ state, dispatch }, entry) {
+    try {
+      await Rpc.asyncData(state.reportsManager, 'removeReportEntry', entry)
+      await dispatch('loadReports')
+      return { success: true }
+    } catch (error) {
+      Util.handleException(error, 'Failed to delete report')
+      return { success: false, error }
+    }
+  },
+
+  /**
+   * Fetches the list of available database tables from the reportsManager.
+   * Skips the RPC call if tables are already loaded or the manager is not initialized.
+   */
+  async fetchTables({ state, commit }) {
+    if (state.tables.length) return
+    if (!state.reportsManager) return
+    try {
+      const result = await Rpc.asyncData(state.reportsManager, 'getTables')
+      if (result) commit('SET_TABLES', result)
+    } catch (error) {
+      Util.handleException(error)
     }
   },
 

--- a/untangle-vue-ui/source/yarn.lock
+++ b/untangle-vue-ui/source/yarn.lock
@@ -3662,9 +3662,9 @@ electron-to-chromium@^1.5.173:
   integrity sha512-rFCxROw7aOe4uPTfIAx+rXv9cEcGx+buAF4npnhtTqCJk5KDFRnh3+KYj7rdVh6lsFt5/aPs+Irj9rZ33WMA7w==
 
 electron-to-chromium@^1.5.402:
-  version "1.5.406"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.406.tgz#c1d2ddac21d01e92f0ddd2951d37642501d4a7f1"
-  integrity sha512-hWH5ORBi3d0IipnMh7BN5GDTaAmrSSSWmznwt2zltdiRNEWoEQyTwF0FFSBxzHO7hLSRT6loQu3IQGV0wg/Tvg==
+  version "1.5.408"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.408.tgz#73744ee8fabe4e689e477d767f1172877ee61e46"
+  integrity sha512-SLoprcYpJ/OH2v2ps0+N5biv9H4/KBT3+YmmDew64TwK5y9j2wv7pMOFY7IorVkyMtEyLSCRlXKLsNlakeAlPw==
 
 element-resize-detector@^1.2.1:
   version "1.2.4"
@@ -8311,8 +8311,8 @@ vuex@^3.6.2:
   integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 vuntangle@untangle/vuntangle:
-  version "1.62.65"
-  resolved "git+ssh://git@github.com/untangle/vuntangle.git#90be03cbcf346cded786c2a9144b006be893dd52"
+  version "1.62.67"
+  resolved "git+ssh://git@github.com/untangle/vuntangle.git#6f171d63dbad5f4faa31cd854ef04fd304b6343d"
   dependencies:
     "@ag-grid-community/client-side-row-model" "^25.3.0"
     "@ag-grid-community/core" "^25.3.0"


### PR DESCRIPTION
## Summary
- Implemented the Report Edit/Add page (`ReportEdit.vue`) as an NGFW wrapper around vuntangle's shared `ReportEdit` component
- Added `saveReport` and `deleteReport` Vuex store actions with RPC integration (`saveReportEntry` / `removeReportEntry`)
- Added shared `onEditReport` navigation helper in `reportsMixin.js` for edit/create routing
- Added JSDoc comments across report components and store actions following existing codebase standards
- Updated `REPORTS_IMPLEMENTATION.md` with full documentation of the report editor architecture, vuntangle tab-based design, and current implementation status

## Flows implemented
- **Create**: Reports landing → `/reports/create` → blank editor → save generates `uniqueId` → navigates to detail view
- **Edit**: Report details → `/reports/edit/:cat/:rep` → editor with existing data → update via RPC → navigates to detail view
- **Delete**: Confirm dialog → RPC `removeReportEntry` → navigates to reports landing
- **Refresh**: Reloads full report list from backend